### PR TITLE
feat: initialize Room data layer without FTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# AI Personal Assistant (Android)
+
+## Local Database Schema
+
+```
+users                 notes                    contacts
+-----                 -----                    --------
+id (PK)               id (PK)                  id (PK)
+name                  user_id (FK→users.id)    name
+email                 title                    email
+created_at            body                     phone
+                      created_at               meta_json
+                      updated_at
+
+event_types           events                   event_details
+-----------           ------                   -------------
+id (PK)               id (PK)                  id (PK)
+type_name (unique)    user_id (FK)             event_id (FK→events.id)
+                      type_id (FK→event_types) description
+                      title
+                      start_at
+                      end_at
+                      location
+                      status
+
+ event_notifications          auth_tokens             ingest_items
+ --------------------         -----------             ------------
+ id (PK)                      provider (PK)           id (PK)
+ event_id (FK→events.id)      access_token            source
+ notify_at                    refresh_token           type
+ channel                      scope                   title
+                              expires_at              body
+                                                       timestamp
+                                                       due_date
+                                                       confidence
+                                                       meta_json
+```
+
+- `ingest_items` includes indices on `timestamp` and `due_date` to support time based queries.
+- Full-text search tables are intentionally omitted in this iteration per project direction.
+- Database version 1 ships without migrations; a dedicated container is in place for future upgrades.
+
+## Testing
+
+Run the full unit test suite:
+
+```bash
+./gradlew test
+```

--- a/app/src/main/java/com/example/agent_app/data/dao/AuthTokenDao.kt
+++ b/app/src/main/java/com/example/agent_app/data/dao/AuthTokenDao.kt
@@ -1,0 +1,24 @@
+package com.example.agent_app.data.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+import com.example.agent_app.data.entity.AuthToken
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface AuthTokenDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(token: AuthToken)
+
+    @Update
+    suspend fun update(token: AuthToken)
+
+    @Query("SELECT * FROM auth_tokens WHERE provider = :provider")
+    suspend fun getByProvider(provider: String): AuthToken?
+
+    @Query("SELECT * FROM auth_tokens")
+    fun observeAll(): Flow<List<AuthToken>>
+}

--- a/app/src/main/java/com/example/agent_app/data/dao/ContactDao.kt
+++ b/app/src/main/java/com/example/agent_app/data/dao/ContactDao.kt
@@ -1,0 +1,28 @@
+package com.example.agent_app.data.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+import com.example.agent_app.data.entity.Contact
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface ContactDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(contact: Contact): Long
+
+    @Update
+    suspend fun update(contact: Contact)
+
+    @Delete
+    suspend fun delete(contact: Contact)
+
+    @Query("SELECT * FROM contacts WHERE id = :id")
+    suspend fun getById(id: Long): Contact?
+
+    @Query("SELECT * FROM contacts ORDER BY name ASC")
+    fun observeAll(): Flow<List<Contact>>
+}

--- a/app/src/main/java/com/example/agent_app/data/dao/EventDao.kt
+++ b/app/src/main/java/com/example/agent_app/data/dao/EventDao.kt
@@ -1,0 +1,55 @@
+package com.example.agent_app.data.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import androidx.room.Update
+import com.example.agent_app.data.entity.Event
+import com.example.agent_app.data.entity.EventDetail
+import com.example.agent_app.data.entity.EventNotification
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface EventDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(event: Event): Long
+
+    @Update
+    suspend fun update(event: Event)
+
+    @Delete
+    suspend fun delete(event: Event)
+
+    @Query("SELECT * FROM events WHERE id = :id")
+    suspend fun getById(id: Long): Event?
+
+    @Query(
+        "SELECT * FROM events WHERE user_id = :userId " +
+            "ORDER BY CASE WHEN start_at IS NULL THEN 1 ELSE 0 END, start_at ASC"
+    )
+    fun observeByUser(userId: Long): Flow<List<Event>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertDetail(detail: EventDetail): Long
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertNotification(notification: EventNotification): Long
+
+    @Query("SELECT * FROM event_details WHERE event_id = :eventId")
+    suspend fun getDetail(eventId: Long): EventDetail?
+
+    @Query("SELECT * FROM event_notifications WHERE event_id = :eventId ORDER BY notify_at ASC")
+    fun observeNotifications(eventId: Long): Flow<List<EventNotification>>
+
+    @Transaction
+    suspend fun replaceNotifications(eventId: Long, notifications: List<EventNotification>) {
+        deleteNotifications(eventId)
+        notifications.forEach { upsertNotification(it) }
+    }
+
+    @Query("DELETE FROM event_notifications WHERE event_id = :eventId")
+    suspend fun deleteNotifications(eventId: Long)
+}

--- a/app/src/main/java/com/example/agent_app/data/dao/EventTypeDao.kt
+++ b/app/src/main/java/com/example/agent_app/data/dao/EventTypeDao.kt
@@ -1,0 +1,24 @@
+package com.example.agent_app.data.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+import com.example.agent_app.data.entity.EventType
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface EventTypeDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(eventType: EventType): Long
+
+    @Update
+    suspend fun update(eventType: EventType)
+
+    @Query("SELECT * FROM event_types WHERE id = :id")
+    suspend fun getById(id: Long): EventType?
+
+    @Query("SELECT * FROM event_types ORDER BY type_name ASC")
+    fun observeAll(): Flow<List<EventType>>
+}

--- a/app/src/main/java/com/example/agent_app/data/dao/IngestItemDao.kt
+++ b/app/src/main/java/com/example/agent_app/data/dao/IngestItemDao.kt
@@ -1,0 +1,44 @@
+package com.example.agent_app.data.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+import com.example.agent_app.data.entity.IngestItem
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface IngestItemDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(item: IngestItem)
+
+    @Update
+    suspend fun update(item: IngestItem)
+
+    @Delete
+    suspend fun delete(item: IngestItem)
+
+    @Query("SELECT * FROM ingest_items WHERE id = :id")
+    suspend fun getById(id: String): IngestItem?
+
+    @Query("SELECT * FROM ingest_items ORDER BY timestamp DESC LIMIT :limit OFFSET :offset")
+    suspend fun getPaged(limit: Int, offset: Int): List<IngestItem>
+
+    @Query("SELECT * FROM ingest_items WHERE source = :source ORDER BY timestamp DESC")
+    fun observeBySource(source: String): Flow<List<IngestItem>>
+
+    @Query(
+        "SELECT * FROM ingest_items WHERE (:start IS NULL OR timestamp >= :start) " +
+            "AND (:end IS NULL OR timestamp <= :end) ORDER BY timestamp DESC"
+    )
+    suspend fun getByTimestampRange(start: Long?, end: Long?): List<IngestItem>
+
+    @Query(
+        "SELECT * FROM ingest_items WHERE due_date IS NOT NULL " +
+            "AND (:after IS NULL OR due_date >= :after) " +
+            "AND (:before IS NULL OR due_date <= :before) ORDER BY due_date ASC"
+    )
+    fun observeDueBetween(after: Long?, before: Long?): Flow<List<IngestItem>>
+}

--- a/app/src/main/java/com/example/agent_app/data/dao/NoteDao.kt
+++ b/app/src/main/java/com/example/agent_app/data/dao/NoteDao.kt
@@ -1,0 +1,28 @@
+package com.example.agent_app.data.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+import com.example.agent_app.data.entity.Note
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface NoteDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(note: Note): Long
+
+    @Update
+    suspend fun update(note: Note)
+
+    @Delete
+    suspend fun delete(note: Note)
+
+    @Query("SELECT * FROM notes WHERE id = :id")
+    suspend fun getById(id: Long): Note?
+
+    @Query("SELECT * FROM notes WHERE user_id = :userId ORDER BY updated_at DESC")
+    fun observeByUser(userId: Long): Flow<List<Note>>
+}

--- a/app/src/main/java/com/example/agent_app/data/dao/UserDao.kt
+++ b/app/src/main/java/com/example/agent_app/data/dao/UserDao.kt
@@ -1,0 +1,24 @@
+package com.example.agent_app.data.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+import com.example.agent_app.data.entity.User
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface UserDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(user: User): Long
+
+    @Update
+    suspend fun update(user: User)
+
+    @Query("SELECT * FROM users WHERE id = :id")
+    suspend fun getById(id: Long): User?
+
+    @Query("SELECT * FROM users ORDER BY created_at DESC")
+    fun observeAll(): Flow<List<User>>
+}

--- a/app/src/main/java/com/example/agent_app/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/example/agent_app/data/db/AppDatabase.kt
@@ -4,25 +4,56 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
-import androidx.room.TypeConverters
+import com.example.agent_app.data.dao.AuthTokenDao
+import com.example.agent_app.data.dao.ContactDao
+import com.example.agent_app.data.dao.EventDao
+import com.example.agent_app.data.dao.EventTypeDao
+import com.example.agent_app.data.dao.IngestItemDao
+import com.example.agent_app.data.dao.NoteDao
+import com.example.agent_app.data.dao.UserDao
+import com.example.agent_app.data.db.migrations.DatabaseMigrations
+import com.example.agent_app.data.entity.AuthToken
+import com.example.agent_app.data.entity.Contact
+import com.example.agent_app.data.entity.Event
+import com.example.agent_app.data.entity.EventDetail
+import com.example.agent_app.data.entity.EventNotification
+import com.example.agent_app.data.entity.EventType
+import com.example.agent_app.data.entity.IngestItem
+import com.example.agent_app.data.entity.Note
+import com.example.agent_app.data.entity.User
 
 @Database(
-    entities = [IngestItemEntity::class, IngestItemFtsEntity::class, AuthTokenEntity::class],
+    entities = [
+        Contact::class,
+        User::class,
+        Note::class,
+        EventType::class,
+        Event::class,
+        EventDetail::class,
+        EventNotification::class,
+        AuthToken::class,
+        IngestItem::class,
+    ],
     version = 1,
-    exportSchema = true
+    exportSchema = true,
 )
-@TypeConverters(Converters::class)
 abstract class AppDatabase : RoomDatabase() {
 
+    abstract fun contactDao(): ContactDao
+    abstract fun userDao(): UserDao
+    abstract fun noteDao(): NoteDao
+    abstract fun eventTypeDao(): EventTypeDao
+    abstract fun eventDao(): EventDao
+    abstract fun authTokenDao(): AuthTokenDao
     abstract fun ingestItemDao(): IngestItemDao
 
-    abstract fun authTokenDao(): AuthTokenDao
-
     companion object {
-        const val DATABASE_NAME: String = "agent_app.db"
+        private const val DATABASE_NAME = "assistant.db"
 
-        fun build(context: Context): AppDatabase =
-            Room.databaseBuilder(context.applicationContext, AppDatabase::class.java, DATABASE_NAME)
-                .build()
+        fun build(context: Context): AppDatabase = Room
+            .databaseBuilder(context, AppDatabase::class.java, DATABASE_NAME)
+            .addMigrations(*DatabaseMigrations.ALL)
+            .fallbackToDestructiveMigrationOnDowngrade()
+            .build()
     }
 }

--- a/app/src/main/java/com/example/agent_app/data/db/migrations/DatabaseMigrations.kt
+++ b/app/src/main/java/com/example/agent_app/data/db/migrations/DatabaseMigrations.kt
@@ -1,0 +1,7 @@
+package com.example.agent_app.data.db.migrations
+
+import androidx.room.migration.Migration
+
+object DatabaseMigrations {
+    val ALL: Array<Migration> = emptyArray()
+}

--- a/app/src/main/java/com/example/agent_app/data/entity/AuthToken.kt
+++ b/app/src/main/java/com/example/agent_app/data/entity/AuthToken.kt
@@ -1,0 +1,18 @@
+package com.example.agent_app.data.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "auth_tokens")
+data class AuthToken(
+    @PrimaryKey
+    val provider: String,
+    @ColumnInfo(name = "access_token")
+    val accessToken: String,
+    @ColumnInfo(name = "refresh_token")
+    val refreshToken: String?,
+    val scope: String?,
+    @ColumnInfo(name = "expires_at")
+    val expiresAt: Long?,
+)

--- a/app/src/main/java/com/example/agent_app/data/entity/Contact.kt
+++ b/app/src/main/java/com/example/agent_app/data/entity/Contact.kt
@@ -1,0 +1,16 @@
+package com.example.agent_app.data.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "contacts")
+data class Contact(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    val name: String,
+    val email: String?,
+    val phone: String?,
+    @ColumnInfo(name = "meta_json")
+    val metaJson: String? = null,
+)

--- a/app/src/main/java/com/example/agent_app/data/entity/Event.kt
+++ b/app/src/main/java/com/example/agent_app/data/entity/Event.kt
@@ -1,0 +1,46 @@
+package com.example.agent_app.data.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "events",
+    foreignKeys = [
+        ForeignKey(
+            entity = User::class,
+            parentColumns = ["id"],
+            childColumns = ["user_id"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+        ForeignKey(
+            entity = EventType::class,
+            parentColumns = ["id"],
+            childColumns = ["type_id"],
+            onDelete = ForeignKey.SET_NULL,
+        ),
+    ],
+    indices = [
+        Index(value = ["user_id"]),
+        Index(value = ["type_id"]),
+        Index(value = ["start_at"]),
+        Index(value = ["end_at"]),
+    ]
+)
+data class Event(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    @ColumnInfo(name = "user_id")
+    val userId: Long,
+    @ColumnInfo(name = "type_id")
+    val typeId: Long?,
+    val title: String,
+    @ColumnInfo(name = "start_at")
+    val startAt: Long?,
+    @ColumnInfo(name = "end_at")
+    val endAt: Long?,
+    val location: String?,
+    val status: String?,
+)

--- a/app/src/main/java/com/example/agent_app/data/entity/EventDetail.kt
+++ b/app/src/main/java/com/example/agent_app/data/entity/EventDetail.kt
@@ -1,0 +1,27 @@
+package com.example.agent_app.data.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "event_details",
+    foreignKeys = [
+        ForeignKey(
+            entity = Event::class,
+            parentColumns = ["id"],
+            childColumns = ["event_id"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [Index(value = ["event_id"], unique = true)]
+)
+data class EventDetail(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    @ColumnInfo(name = "event_id")
+    val eventId: Long,
+    val description: String,
+)

--- a/app/src/main/java/com/example/agent_app/data/entity/EventNotification.kt
+++ b/app/src/main/java/com/example/agent_app/data/entity/EventNotification.kt
@@ -1,0 +1,29 @@
+package com.example.agent_app.data.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "event_notifications",
+    foreignKeys = [
+        ForeignKey(
+            entity = Event::class,
+            parentColumns = ["id"],
+            childColumns = ["event_id"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [Index(value = ["event_id"])]
+)
+data class EventNotification(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    @ColumnInfo(name = "event_id")
+    val eventId: Long,
+    @ColumnInfo(name = "notify_at")
+    val notifyAt: Long,
+    val channel: String,
+)

--- a/app/src/main/java/com/example/agent_app/data/entity/EventType.kt
+++ b/app/src/main/java/com/example/agent_app/data/entity/EventType.kt
@@ -1,0 +1,17 @@
+package com.example.agent_app.data.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "event_types",
+    indices = [Index(value = ["type_name"], unique = true)]
+)
+data class EventType(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    @ColumnInfo(name = "type_name")
+    val typeName: String,
+)

--- a/app/src/main/java/com/example/agent_app/data/entity/IngestItem.kt
+++ b/app/src/main/java/com/example/agent_app/data/entity/IngestItem.kt
@@ -1,0 +1,28 @@
+package com.example.agent_app.data.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "ingest_items",
+    indices = [
+        Index(value = ["timestamp"]),
+        Index(value = ["due_date"]),
+    ]
+)
+data class IngestItem(
+    @PrimaryKey
+    val id: String,
+    val source: String,
+    val type: String?,
+    val title: String?,
+    val body: String?,
+    val timestamp: Long,
+    @ColumnInfo(name = "due_date")
+    val dueDate: Long?,
+    val confidence: Double?,
+    @ColumnInfo(name = "meta_json")
+    val metaJson: String?,
+)

--- a/app/src/main/java/com/example/agent_app/data/entity/Note.kt
+++ b/app/src/main/java/com/example/agent_app/data/entity/Note.kt
@@ -1,0 +1,32 @@
+package com.example.agent_app.data.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "notes",
+    foreignKeys = [
+        ForeignKey(
+            entity = User::class,
+            parentColumns = ["id"],
+            childColumns = ["user_id"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [Index(value = ["user_id"])]
+)
+data class Note(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    @ColumnInfo(name = "user_id")
+    val userId: Long,
+    val title: String,
+    val body: String,
+    @ColumnInfo(name = "created_at")
+    val createdAt: Long,
+    @ColumnInfo(name = "updated_at")
+    val updatedAt: Long,
+)

--- a/app/src/main/java/com/example/agent_app/data/entity/User.kt
+++ b/app/src/main/java/com/example/agent_app/data/entity/User.kt
@@ -1,0 +1,15 @@
+package com.example.agent_app.data.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "users")
+data class User(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    val name: String,
+    val email: String,
+    @ColumnInfo(name = "created_at")
+    val createdAt: Long,
+)

--- a/app/src/test/java/com/example/agent_app/data/db/AppDatabaseTest.kt
+++ b/app/src/test/java/com/example/agent_app/data/db/AppDatabaseTest.kt
@@ -3,102 +3,258 @@ package com.example.agent_app.data.db
 import android.content.Context
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
-import kotlinx.coroutines.runBlocking
+import com.example.agent_app.data.dao.AuthTokenDao
+import com.example.agent_app.data.dao.ContactDao
+import com.example.agent_app.data.dao.EventDao
+import com.example.agent_app.data.dao.EventTypeDao
+import com.example.agent_app.data.dao.IngestItemDao
+import com.example.agent_app.data.dao.NoteDao
+import com.example.agent_app.data.dao.UserDao
+import com.example.agent_app.data.entity.AuthToken
+import com.example.agent_app.data.entity.Contact
+import com.example.agent_app.data.entity.Event
+import com.example.agent_app.data.entity.EventDetail
+import com.example.agent_app.data.entity.EventNotification
+import com.example.agent_app.data.entity.EventType
+import com.example.agent_app.data.entity.IngestItem
+import com.example.agent_app.data.entity.Note
+import com.example.agent_app.data.entity.User
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import java.io.IOException
-import java.time.Instant
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class AppDatabaseTest {
 
-    private lateinit var context: Context
     private lateinit var database: AppDatabase
+    private lateinit var contactDao: ContactDao
+    private lateinit var userDao: UserDao
+    private lateinit var noteDao: NoteDao
+    private lateinit var eventTypeDao: EventTypeDao
+    private lateinit var eventDao: EventDao
+    private lateinit var authTokenDao: AuthTokenDao
+    private lateinit var ingestItemDao: IngestItemDao
 
     @Before
-    fun setUp() {
-        context = ApplicationProvider.getApplicationContext()
+    fun setup() {
+        val context: Context = ApplicationProvider.getApplicationContext()
         database = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
             .allowMainThreadQueries()
             .build()
+        contactDao = database.contactDao()
+        userDao = database.userDao()
+        noteDao = database.noteDao()
+        eventTypeDao = database.eventTypeDao()
+        eventDao = database.eventDao()
+        authTokenDao = database.authTokenDao()
+        ingestItemDao = database.ingestItemDao()
     }
 
     @After
-    @Throws(IOException::class)
     fun tearDown() {
         database.close()
     }
 
     @Test
-    fun upsertAndFetchAuthToken() = runBlocking {
-        val dao = database.authTokenDao()
-        val token = AuthTokenEntity(
-            provider = "google",
-            accountEmail = "jane.doe@example.com",
-            accessToken = "access-123",
-            refreshToken = "refresh-456",
-            scopes = listOf("gmail.readonly", "profile"),
-            expiresAt = Instant.parse("2024-10-01T12:00:00Z"),
-            createdAt = Instant.parse("2024-09-01T08:00:00Z"),
-            updatedAt = Instant.parse("2024-09-01T08:00:00Z")
+    fun contactCrudOperationsWork() = runTest {
+        val contactId = contactDao.upsert(
+            Contact(
+                name = "Ada Lovelace",
+                email = "ada@example.com",
+                phone = "010-1234-5678",
+                metaJson = "{\"company\":\"Analytical Engines\"}",
+            )
         )
 
-        val rowId = dao.upsert(token)
-        assertTrue(rowId > 0)
-
-        val stored = dao.find("google", "jane.doe@example.com")
+        var stored = contactDao.getById(contactId)
         assertNotNull(stored)
-        stored!!
-        assertEquals(token.scopes, stored.scopes)
-        assertEquals(token.refreshToken, stored.refreshToken)
+        assertEquals("Ada Lovelace", stored!!.name)
 
-        val deleted = dao.delete("google", "jane.doe@example.com")
-        assertEquals(1, deleted)
-        assertNull(dao.find("google", "jane.doe@example.com"))
+        val updated = stored.copy(phone = "010-8765-4321")
+        contactDao.update(updated)
+        stored = contactDao.getById(contactId)
+        assertEquals("010-8765-4321", stored!!.phone)
+
+        contactDao.delete(updated)
+        assertNull(contactDao.getById(contactId))
     }
 
     @Test
-    fun ftsSearchReturnsRelevantIngestItems() = runBlocking {
-        val dao = database.ingestItemDao()
-        val first = IngestItemEntity(
-            source = "gmail",
-            externalId = "A",
-            subject = "Weekly team sync",
-            body = "We discussed launch blockers and action items.",
-            labels = listOf("work", "team"),
-            receivedAt = Instant.parse("2024-09-10T09:00:00Z"),
-            createdAt = Instant.parse("2024-09-10T09:00:00Z"),
-            updatedAt = Instant.parse("2024-09-10T09:00:00Z")
-        )
-        val second = IngestItemEntity(
-            source = "gmail",
-            externalId = "B",
-            subject = "Personal reminder",
-            body = "Pick up coffee beans on the way home.",
-            labels = listOf("personal"),
-            receivedAt = Instant.parse("2024-09-09T18:30:00Z"),
-            createdAt = Instant.parse("2024-09-09T18:30:00Z"),
-            updatedAt = Instant.parse("2024-09-09T18:30:00Z")
+    fun userAndNoteRelationshipIsMaintained() = runTest {
+        val userId = userDao.upsert(
+            User(
+                name = "Test User",
+                email = "user@example.com",
+                createdAt = 1727443200000L,
+            )
         )
 
-        dao.upsert(first)
-        dao.upsert(second)
+        val noteId = noteDao.upsert(
+            Note(
+                userId = userId,
+                title = "Meeting notes",
+                body = "Discuss quarterly goals",
+                createdAt = 1727443300000L,
+                updatedAt = 1727443300000L,
+            )
+        )
 
-        val results = dao.search("launch")
-        assertEquals(1, results.size)
-        assertEquals("Weekly team sync", results.first().subject)
-        assertEquals(first.labels, results.first().labels)
+        val fetched = noteDao.getById(noteId)
+        assertNotNull(fetched)
+        assertEquals(userId, fetched!!.userId)
 
-        val lookup = dao.findBySourceAndExternalId("gmail", "B")
-        assertNotNull(lookup)
-        assertEquals(second.body, lookup?.body)
+        val updated = fetched.copy(updatedAt = 1727444300000L)
+        noteDao.update(updated)
 
-        val recent = dao.getRecent(limit = 1)
-        assertEquals(1, recent.size)
-        assertEquals(first.externalId, recent.first().externalId)
+        val notes = noteDao.observeByUser(userId).first()
+        assertEquals(1, notes.size)
+        assertEquals(1727444300000L, notes.first().updatedAt)
+    }
+
+    @Test
+    fun eventEntitiesSupportDetailsAndNotifications() = runTest {
+        val userId = userDao.upsert(
+            User(
+                name = "Calendar Owner",
+                email = "owner@example.com",
+                createdAt = 1727443200000L,
+            )
+        )
+        val typeId = eventTypeDao.upsert(EventType(typeName = "Meeting"))
+
+        val eventId = eventDao.upsert(
+            Event(
+                userId = userId,
+                typeId = typeId,
+                title = "Strategy Sync",
+                startAt = 1727450000000L,
+                endAt = 1727453600000L,
+                location = "Conference Room",
+                status = "confirmed",
+            )
+        )
+
+        eventDao.upsertDetail(
+            EventDetail(
+                eventId = eventId,
+                description = "Align on roadmap priorities",
+            )
+        )
+
+        val initialNotifications = listOf(
+            EventNotification(eventId = eventId, notifyAt = 1727446400000L, channel = "push"),
+            EventNotification(eventId = eventId, notifyAt = 1727448200000L, channel = "email"),
+        )
+        eventDao.replaceNotifications(eventId, initialNotifications)
+
+        val detail = eventDao.getDetail(eventId)
+        assertNotNull(detail)
+        assertEquals("Align on roadmap priorities", detail!!.description)
+
+        val notifications = eventDao.observeNotifications(eventId).first()
+        assertEquals(2, notifications.size)
+        assertEquals("push", notifications.first().channel)
+
+        val updatedNotifications = listOf(
+            EventNotification(eventId = eventId, notifyAt = 1727449200000L, channel = "push"),
+        )
+        eventDao.replaceNotifications(eventId, updatedNotifications)
+
+        val refreshed = eventDao.observeNotifications(eventId).first()
+        assertEquals(1, refreshed.size)
+        assertEquals(1727449200000L, refreshed.first().notifyAt)
+    }
+
+    @Test
+    fun authTokensPersistAndUpdate() = runTest {
+        val provider = "google"
+        val token = AuthToken(
+            provider = provider,
+            accessToken = "access",
+            refreshToken = "refresh",
+            scope = "scope",
+            expiresAt = 1727450000L,
+        )
+
+        authTokenDao.upsert(token)
+        var stored = authTokenDao.getByProvider(provider)
+        assertNotNull(stored)
+        assertEquals("access", stored!!.accessToken)
+
+        val updated = token.copy(accessToken = "updated_access")
+        authTokenDao.upsert(updated)
+        stored = authTokenDao.getByProvider(provider)
+        assertEquals("updated_access", stored!!.accessToken)
+    }
+
+    @Test
+    fun ingestItemsSupportQueryingByTimeAndDueDate() = runTest {
+        val baseTimestamp = 1727443200000L
+        val items = listOf(
+            IngestItem(
+                id = "1",
+                source = "gmail",
+                type = "email",
+                title = "Welcome",
+                body = "Welcome to the service",
+                timestamp = baseTimestamp,
+                dueDate = null,
+                confidence = null,
+                metaJson = null,
+            ),
+            IngestItem(
+                id = "2",
+                source = "sms",
+                type = "message",
+                title = "Code",
+                body = "Your OTP is 1234",
+                timestamp = baseTimestamp + 1_000,
+                dueDate = baseTimestamp + 10_000,
+                confidence = 0.9,
+                metaJson = null,
+            ),
+            IngestItem(
+                id = "3",
+                source = "gmail",
+                type = "email",
+                title = "Invoice",
+                body = "Invoice attached",
+                timestamp = baseTimestamp + 2_000,
+                dueDate = baseTimestamp + 20_000,
+                confidence = 0.5,
+                metaJson = null,
+            ),
+        )
+
+        items.forEach { ingestItemDao.upsert(it) }
+
+        val page = ingestItemDao.getPaged(limit = 2, offset = 0)
+        assertEquals(2, page.size)
+        assertEquals("3", page.first().id)
+
+        val gmailItems = ingestItemDao.observeBySource("gmail").first()
+        assertEquals(2, gmailItems.size)
+
+        val rangeItems = ingestItemDao.getByTimestampRange(
+            start = baseTimestamp + 500,
+            end = baseTimestamp + 1_500,
+        )
+        assertEquals(1, rangeItems.size)
+        assertEquals("2", rangeItems.first().id)
+
+        val dueItems = ingestItemDao.observeDueBetween(
+            after = baseTimestamp + 5_000,
+            before = baseTimestamp + 25_000,
+        ).first()
+        assertEquals(listOf("2", "3"), dueItems.map { it.id })
+
+        ingestItemDao.delete(items.first())
+        assertNull(ingestItemDao.getById("1"))
     }
 }


### PR DESCRIPTION
## Summary
- add Room entities, DAOs, and a database builder covering contacts, tasks, events, auth tokens, and ingest items without FTS tables
- wire an initial migrations container and document the schema layout in the README
- expand database tests to exercise CRUD flows, relationships, and ingest item queries across the new tables

## Testing
- ./gradlew test *(fails: Gradle wrapper download blocked by proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d9287e1b28832085a1fa6d87c24642