### PR TITLE
feat: migrate phase 3 UI to compose and kotlin serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,20 @@ type_name (unique)    user_id (FK)             event_id (FK→events.id)
 - Full-text search tables are intentionally omitted in this iteration per project direction.
 - Database version 1 ships without migrations; a dedicated container is in place for future upgrades.
 
+## Gmail Ingestion (Phase 3)
+
+Phase 3 introduces a Jetpack Compose driven home screen and a Gmail ingestion client powered by Retrofit + Kotlinx Serialization. To exercise the flow:
+
+1. Complete the Google OAuth authorization code flow separately and obtain an access token with the `https://www.googleapis.com/auth/gmail.readonly` scope. A refresh token is optional but can be stored for future automation.
+2. Launch the Android app. The Compose home screen contains two cards: **Google 로그인 설정** for credential storage and **Gmail 수집함** for inbox monitoring. Enter the access token (and optional refresh token, scope, or expiry) and press **토큰 저장**. The token metadata is persisted in Room for reuse.
+3. Press **최근 20개 동기화** within the **Gmail 수집함** card. The app calls the Gmail REST API, retrieves the most recent 20 messages, and upserts them into the `ingest_items` table using the Gmail message ID as the primary key.
+4. Stored messages render immediately in the Compose list with subject, snippet, and received timestamp. If Gmail returns `401 Unauthorized`, the UI surfaces a snackbar prompting the user to refresh credentials.
+
+> ⚠️ **Security note:** Real deployments must exchange the Google server auth code server-side and load tokens into the app's encrypted storage. The manual token entry workflow above is provided strictly for local development.
+
 ## Testing
 
-Run the full unit test suite:
+Run the full unit test suite (includes Gmail repository coverage):
 
 ```bash
 ./gradlew test

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,8 @@ plugins {
     alias(libs.plugins.ksp)
 }
 
+apply(plugin = "org.jetbrains.kotlin.plugin.serialization")
+
 android {
     namespace = "com.example.agent_app"
     compileSdk = 36
@@ -16,6 +18,7 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        vectorDrawables.useSupportLibrary = true
     }
 
     buildTypes {
@@ -34,6 +37,12 @@ android {
     kotlinOptions {
         jvmTarget = "11"
     }
+    buildFeatures {
+        compose = true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion = libs.versions.composeCompiler.get()
+    }
 }
 
 ksp {
@@ -46,10 +55,28 @@ dependencies {
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
-    implementation(libs.material)
     implementation(libs.androidx.room.runtime)
     implementation(libs.androidx.room.ktx)
     implementation(libs.kotlinx.coroutines.android)
+    implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.lifecycle.viewmodel.ktx)
+    implementation(libs.androidx.activity.ktx)
+
+    implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.compose.ui)
+    implementation(libs.androidx.compose.ui.graphics)
+    implementation(libs.androidx.compose.ui.tooling.preview)
+    implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.lifecycle.runtime.compose)
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
+
+    implementation(libs.retrofit.core)
+    implementation(libs.retrofit.kotlinx.serialization)
+    implementation(libs.okhttp)
+    implementation(libs.okhttp.logging)
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.androidx.security.crypto)
 
     ksp(libs.androidx.room.compiler)
 
@@ -60,4 +87,11 @@ dependencies {
 
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
+    androidTestImplementation(platform(libs.androidx.compose.bom))
+    androidTestImplementation(libs.androidx.compose.ui.test.junit4)
+
+    debugImplementation(platform(libs.androidx.compose.bom))
+    debugImplementation(libs.androidx.compose.ui.tooling)
+    debugImplementation(libs.androidx.compose.ui.test.manifest)
+
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -10,6 +12,16 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.Agent_App" />
+        android:theme="@style/Theme.Agent_App">
+        <activity
+            android:name=".ui.MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
 
 </manifest>

--- a/app/src/main/java/com/example/agent_app/data/repo/AuthRepository.kt
+++ b/app/src/main/java/com/example/agent_app/data/repo/AuthRepository.kt
@@ -1,0 +1,48 @@
+package com.example.agent_app.data.repo
+
+import com.example.agent_app.data.dao.AuthTokenDao
+import com.example.agent_app.data.entity.AuthToken
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+
+class AuthRepository(
+    private val dao: AuthTokenDao,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) {
+    fun observeGoogleToken(): Flow<AuthToken?> =
+        dao.observeAll().map { tokens -> tokens.firstOrNull { it.provider == GOOGLE_PROVIDER } }
+
+    suspend fun getGoogleToken(): AuthToken? = withContext(dispatcher) {
+        dao.getByProvider(GOOGLE_PROVIDER)
+    }
+
+    suspend fun upsertGoogleToken(
+        accessToken: String,
+        refreshToken: String?,
+        scope: String?,
+        expiresAt: Long?,
+    ) = withContext(dispatcher) {
+        val token = AuthToken(
+            provider = GOOGLE_PROVIDER,
+            accessToken = accessToken,
+            refreshToken = refreshToken,
+            scope = scope,
+            expiresAt = expiresAt,
+        )
+        dao.upsert(token)
+    }
+
+    suspend fun clearGoogleToken() = withContext(dispatcher) {
+        val current = dao.getByProvider(GOOGLE_PROVIDER)
+        if (current != null) {
+            dao.delete(current)
+        }
+    }
+
+    private companion object {
+        const val GOOGLE_PROVIDER = "google"
+    }
+}

--- a/app/src/main/java/com/example/agent_app/data/repo/GmailRepository.kt
+++ b/app/src/main/java/com/example/agent_app/data/repo/GmailRepository.kt
@@ -1,0 +1,108 @@
+package com.example.agent_app.data.repo
+
+import com.example.agent_app.data.entity.IngestItem
+import com.example.agent_app.gmail.GmailApi
+import com.example.agent_app.gmail.GmailMessage
+import java.io.IOException
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONArray
+import org.json.JSONObject
+import retrofit2.HttpException
+
+class GmailRepository(
+    private val api: GmailApi,
+    private val ingestRepository: IngestRepository,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) {
+    suspend fun syncRecentMessages(accessToken: String): GmailSyncResult = withContext(dispatcher) {
+        if (accessToken.isBlank()) {
+            return@withContext GmailSyncResult.MissingToken
+        }
+        try {
+            val authorization = "Bearer $accessToken"
+            val listResponse = api.listMessages(
+                authorization = authorization,
+                userId = "me",
+                maxResults = 20,
+            )
+            if (listResponse.messages.isEmpty()) {
+                return@withContext GmailSyncResult.Success(upsertedCount = 0)
+            }
+            var upserted = 0
+            listResponse.messages.forEach { reference ->
+                val message = api.getMessage(
+                    authorization = authorization,
+                    userId = "me",
+                    messageId = reference.id,
+                    format = "metadata",
+                    metadataHeaders = listOf("Subject", "Date"),
+                )
+                val ingestItem = message.toIngestItem()
+                ingestRepository.upsert(ingestItem)
+                upserted += 1
+            }
+            GmailSyncResult.Success(upserted)
+        } catch (exception: HttpException) {
+            when (exception.code()) {
+                401 -> GmailSyncResult.Unauthorized
+                else -> GmailSyncResult.NetworkError(exception.message())
+            }
+        } catch (io: IOException) {
+            GmailSyncResult.NetworkError(io.message ?: "IO error")
+        } catch (throwable: Throwable) {
+            GmailSyncResult.NetworkError(throwable.message ?: "Unknown error")
+        }
+    }
+}
+
+sealed class GmailSyncResult {
+    data class Success(val upsertedCount: Int) : GmailSyncResult()
+    data class NetworkError(val message: String) : GmailSyncResult()
+    object Unauthorized : GmailSyncResult()
+    object MissingToken : GmailSyncResult()
+}
+
+private val rfc1123Formatter: DateTimeFormatter =
+    DateTimeFormatter.RFC_1123_DATE_TIME.withZone(ZoneId.of("UTC"))
+
+private fun GmailMessage.toIngestItem(): IngestItem {
+    val subject = payload?.headers?.firstOrNull { it.name.equals("Subject", ignoreCase = true) }?.value
+    val dateHeader = payload?.headers?.firstOrNull { it.name.equals("Date", ignoreCase = true) }?.value
+    val timestamp = parseInternalDate(internalDate, dateHeader)
+    val metadata = JSONObject().apply {
+        put("threadId", threadId)
+        put("labelIds", JSONArray(labelIds ?: emptyList<String>()))
+    }
+    return IngestItem(
+        id = id,
+        source = SOURCE_GMAIL,
+        type = TYPE_EMAIL,
+        title = subject ?: snippet,
+        body = snippet,
+        timestamp = timestamp.toEpochMilli(),
+        dueDate = null,
+        confidence = null,
+        metaJson = metadata.toString(),
+    )
+}
+
+private fun parseInternalDate(internalDate: String?, dateHeader: String?): Instant {
+    internalDate?.toLongOrNull()?.let { return Instant.ofEpochMilli(it) }
+    if (!dateHeader.isNullOrBlank()) {
+        try {
+            return Instant.from(rfc1123Formatter.parse(dateHeader))
+        } catch (_: DateTimeParseException) {
+            // Fallback below
+        }
+    }
+    return Instant.now()
+}
+
+private const val SOURCE_GMAIL = "gmail"
+private const val TYPE_EMAIL = "email"

--- a/app/src/main/java/com/example/agent_app/data/repo/IngestRepository.kt
+++ b/app/src/main/java/com/example/agent_app/data/repo/IngestRepository.kt
@@ -1,0 +1,19 @@
+package com.example.agent_app.data.repo
+
+import com.example.agent_app.data.dao.IngestItemDao
+import com.example.agent_app.data.entity.IngestItem
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.withContext
+
+class IngestRepository(
+    private val dao: IngestItemDao,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) {
+    suspend fun upsert(item: IngestItem) = withContext(dispatcher) {
+        dao.upsert(item)
+    }
+
+    fun observeBySource(source: String): Flow<List<IngestItem>> = dao.observeBySource(source)
+}

--- a/app/src/main/java/com/example/agent_app/gmail/GmailApi.kt
+++ b/app/src/main/java/com/example/agent_app/gmail/GmailApi.kt
@@ -1,0 +1,27 @@
+package com.example.agent_app.gmail
+
+import retrofit2.http.GET
+import retrofit2.http.Header
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+interface GmailApi {
+    @GET("gmail/v1/users/{userId}/messages")
+    suspend fun listMessages(
+        @Header("Authorization") authorization: String,
+        @Path("userId") userId: String,
+        @Query("maxResults") maxResults: Int = 20,
+        @Query("q") query: String? = null,
+        @Query("pageToken") pageToken: String? = null,
+        @Query("includeSpamTrash") includeSpamTrash: Boolean = false,
+    ): GmailMessageListResponse
+
+    @GET("gmail/v1/users/{userId}/messages/{messageId}")
+    suspend fun getMessage(
+        @Header("Authorization") authorization: String,
+        @Path("userId") userId: String,
+        @Path("messageId") messageId: String,
+        @Query("format") format: String = "metadata",
+        @Query("metadataHeaders") metadataHeaders: List<String> = listOf("Subject", "Date"),
+    ): GmailMessage
+}

--- a/app/src/main/java/com/example/agent_app/gmail/GmailModels.kt
+++ b/app/src/main/java/com/example/agent_app/gmail/GmailModels.kt
@@ -1,0 +1,38 @@
+package com.example.agent_app.gmail
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GmailMessageListResponse(
+    val messages: List<GmailMessageReference> = emptyList(),
+    @SerialName("nextPageToken")
+    val nextPageToken: String? = null,
+)
+
+@Serializable
+data class GmailMessageReference(
+    val id: String,
+    val threadId: String? = null,
+)
+
+@Serializable
+data class GmailMessage(
+    val id: String,
+    val threadId: String? = null,
+    val snippet: String? = null,
+    val labelIds: List<String>? = null,
+    val internalDate: String? = null,
+    val payload: GmailPayload? = null,
+)
+
+@Serializable
+data class GmailPayload(
+    val headers: List<GmailHeader>? = null,
+)
+
+@Serializable
+data class GmailHeader(
+    val name: String,
+    val value: String? = null,
+)

--- a/app/src/main/java/com/example/agent_app/gmail/GmailServiceFactory.kt
+++ b/app/src/main/java/com/example/agent_app/gmail/GmailServiceFactory.kt
@@ -1,0 +1,43 @@
+package com.example.agent_app.gmail
+
+import java.util.concurrent.TimeUnit
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
+
+object GmailServiceFactory {
+    private const val BASE_URL = "https://www.googleapis.com/"
+
+    fun create(
+        enableLogging: Boolean = false,
+    ): GmailApi {
+        val loggingInterceptor = HttpLoggingInterceptor().apply {
+            level = if (enableLogging) {
+                HttpLoggingInterceptor.Level.BODY
+            } else {
+                HttpLoggingInterceptor.Level.NONE
+            }
+        }
+        val client = OkHttpClient.Builder()
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .addInterceptor(loggingInterceptor)
+            .build()
+
+        val json = Json {
+            ignoreUnknownKeys = true
+            explicitNulls = false
+        }
+
+        val retrofit = Retrofit.Builder()
+            .baseUrl(BASE_URL)
+            .client(client)
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+            .build()
+
+        return retrofit.create(GmailApi::class.java)
+    }
+}

--- a/app/src/main/java/com/example/agent_app/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/agent_app/ui/MainActivity.kt
@@ -1,0 +1,61 @@
+package com.example.agent_app.ui
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.example.agent_app.data.db.AppDatabase
+import com.example.agent_app.data.repo.AuthRepository
+import com.example.agent_app.data.repo.GmailRepository
+import com.example.agent_app.data.repo.IngestRepository
+import com.example.agent_app.gmail.GmailServiceFactory
+import com.example.agent_app.ui.theme.AgentAppTheme
+
+class MainActivity : ComponentActivity() {
+
+    private val database: AppDatabase by lazy { AppDatabase.build(applicationContext) }
+    private val authRepository: AuthRepository by lazy { AuthRepository(database.authTokenDao()) }
+    private val ingestRepository: IngestRepository by lazy { IngestRepository(database.ingestItemDao()) }
+    private val gmailRepository: GmailRepository by lazy {
+        GmailRepository(
+            api = GmailServiceFactory.create(),
+            ingestRepository = ingestRepository,
+        )
+    }
+
+    private val viewModel: MainViewModel by viewModels {
+        MainViewModelFactory(authRepository, ingestRepository, gmailRepository)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            AgentAppTheme {
+                AssistantApp(viewModel = viewModel)
+            }
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        if (database.isOpen) {
+            database.close()
+        }
+    }
+}
+
+private class MainViewModelFactory(
+    private val authRepository: AuthRepository,
+    private val ingestRepository: IngestRepository,
+    private val gmailRepository: GmailRepository,
+) : ViewModelProvider.Factory {
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        require(modelClass.isAssignableFrom(MainViewModel::class.java)) {
+            "Unknown ViewModel class: ${modelClass.name}"
+        }
+        return MainViewModel(authRepository, ingestRepository, gmailRepository) as T
+    }
+}

--- a/app/src/main/java/com/example/agent_app/ui/MainScreen.kt
+++ b/app/src/main/java/com/example/agent_app/ui/MainScreen.kt
@@ -1,0 +1,298 @@
+package com.example.agent_app.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Divider
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberTopAppBarState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardOptions
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.example.agent_app.R
+import com.example.agent_app.data.entity.IngestItem
+import com.example.agent_app.util.TimeFormatter
+
+@Composable
+fun AssistantApp(viewModel: MainViewModel) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(uiState.loginState.statusMessage, uiState.syncMessage) {
+        val messages = listOfNotNull(uiState.loginState.statusMessage, uiState.syncMessage)
+        if (messages.isNotEmpty()) {
+            messages.forEach { snackbarHostState.showSnackbar(it) }
+            viewModel.consumeStatusMessage()
+        }
+    }
+
+    AssistantScaffold(
+        uiState = uiState,
+        snackbarHostState = snackbarHostState,
+        onAccessTokenChange = viewModel::updateAccessToken,
+        onRefreshTokenChange = viewModel::updateRefreshToken,
+        onScopeChange = viewModel::updateScope,
+        onExpiresAtChange = viewModel::updateExpiresAt,
+        onSaveToken = viewModel::saveToken,
+        onClearToken = viewModel::clearToken,
+        onSync = viewModel::syncGmail,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AssistantScaffold(
+    uiState: AssistantUiState,
+    snackbarHostState: SnackbarHostState,
+    onAccessTokenChange: (String) -> Unit,
+    onRefreshTokenChange: (String) -> Unit,
+    onScopeChange: (String) -> Unit,
+    onExpiresAtChange: (String) -> Unit,
+    onSaveToken: () -> Unit,
+    onClearToken: () -> Unit,
+    onSync: () -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(text = stringResource(id = R.string.app_name)) },
+                scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState()),
+            )
+        },
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
+    ) { paddingValues ->
+        AssistantContent(
+            uiState = uiState,
+            contentPadding = paddingValues,
+            onAccessTokenChange = onAccessTokenChange,
+            onRefreshTokenChange = onRefreshTokenChange,
+            onScopeChange = onScopeChange,
+            onExpiresAtChange = onExpiresAtChange,
+            onSaveToken = onSaveToken,
+            onClearToken = onClearToken,
+            onSync = onSync,
+        )
+    }
+}
+
+@Composable
+private fun AssistantContent(
+    uiState: AssistantUiState,
+    contentPadding: PaddingValues,
+    onAccessTokenChange: (String) -> Unit,
+    onRefreshTokenChange: (String) -> Unit,
+    onScopeChange: (String) -> Unit,
+    onExpiresAtChange: (String) -> Unit,
+    onSaveToken: () -> Unit,
+    onClearToken: () -> Unit,
+    onSync: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(contentPadding)
+            .padding(horizontal = 16.dp, vertical = 24.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp),
+    ) {
+        LoginCard(
+            loginState = uiState.loginState,
+            onAccessTokenChange = onAccessTokenChange,
+            onRefreshTokenChange = onRefreshTokenChange,
+            onScopeChange = onScopeChange,
+            onExpiresAtChange = onExpiresAtChange,
+            onSaveToken = onSaveToken,
+            onClearToken = onClearToken,
+        )
+        GmailCard(
+            items = uiState.gmailItems,
+            isSyncing = uiState.isSyncing,
+            onSync = onSync,
+        )
+    }
+}
+
+@Composable
+private fun LoginCard(
+    loginState: LoginUiState,
+    onAccessTokenChange: (String) -> Unit,
+    onRefreshTokenChange: (String) -> Unit,
+    onScopeChange: (String) -> Unit,
+    onExpiresAtChange: (String) -> Unit,
+    onSaveToken: () -> Unit,
+    onClearToken: () -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+    ) {
+        Column(modifier = Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Text(
+                text = "Google 로그인 설정",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                text = "OAuth 플로우를 완료한 뒤 발급받은 액세스 토큰을 입력하면 최근 Gmail을 동기화할 수 있습니다.",
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            OutlinedTextField(
+                value = loginState.accessTokenInput,
+                onValueChange = onAccessTokenChange,
+                label = { Text("Access Token") },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.None),
+            )
+            OutlinedTextField(
+                value = loginState.refreshTokenInput,
+                onValueChange = onRefreshTokenChange,
+                label = { Text("Refresh Token (선택)") },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.None),
+            )
+            OutlinedTextField(
+                value = loginState.scopeInput,
+                onValueChange = onScopeChange,
+                label = { Text("Scope") },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+            )
+            OutlinedTextField(
+                value = loginState.expiresAtInput,
+                onValueChange = onExpiresAtChange,
+                label = { Text("만료 시각 (epoch ms, 선택)") },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.None),
+            )
+            if (loginState.hasStoredToken) {
+                Divider(modifier = Modifier.padding(top = 8.dp))
+                val scope = loginState.storedScope ?: "미지"
+                val expiry = loginState.storedExpiresAt?.let { TimeFormatter.format(it) } ?: "만료 시간 미설정"
+                Text(
+                    text = "저장된 Scope: $scope",
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Text(
+                    text = "만료 예정: $expiry",
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                Button(onClick = onSaveToken) {
+                    Text(text = "토큰 저장")
+                }
+                TextButton(onClick = onClearToken) {
+                    Text(text = "토큰 삭제")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun GmailCard(
+    items: List<IngestItem>,
+    isSyncing: Boolean,
+    onSync: () -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+    ) {
+        Column(modifier = Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = "Gmail 수집함",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Button(onClick = onSync, enabled = !isSyncing) {
+                    Text(text = "최근 20개 동기화")
+                }
+            }
+            if (isSyncing) {
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
+                    CircularProgressIndicator()
+                }
+            }
+            if (items.isEmpty()) {
+                Text(
+                    text = "저장된 메시지가 없습니다. 동기화를 실행해 보세요.",
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            } else {
+                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    items.forEachIndexed { index, item ->
+                        GmailMessageRow(item)
+                        if (index < items.lastIndex) {
+                            Divider()
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun GmailMessageRow(item: IngestItem) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = item.title ?: "(제목 없음)",
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.Medium,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = item.body.orEmpty(),
+            style = MaterialTheme.typography.bodyMedium,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = "수신: ${TimeFormatter.format(item.timestamp)}",
+            style = MaterialTheme.typography.labelSmall,
+        )
+    }
+}

--- a/app/src/main/java/com/example/agent_app/ui/MainViewModel.kt
+++ b/app/src/main/java/com/example/agent_app/ui/MainViewModel.kt
@@ -1,0 +1,185 @@
+package com.example.agent_app.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.agent_app.data.entity.IngestItem
+import com.example.agent_app.data.repo.AuthRepository
+import com.example.agent_app.data.repo.GmailRepository
+import com.example.agent_app.data.repo.GmailSyncResult
+import com.example.agent_app.data.repo.IngestRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+private const val DEFAULT_GMAIL_SCOPE = "https://www.googleapis.com/auth/gmail.readonly"
+
+class MainViewModel(
+    private val authRepository: AuthRepository,
+    private val ingestRepository: IngestRepository,
+    private val gmailRepository: GmailRepository,
+) : ViewModel() {
+
+    private val loginState = MutableStateFlow(LoginUiState())
+    private val syncState = MutableStateFlow(SyncState())
+
+    private val gmailItemsState = ingestRepository
+        .observeBySource("gmail")
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    val uiState: StateFlow<AssistantUiState> = combine(
+        loginState,
+        gmailItemsState,
+        syncState,
+    ) { login, gmailItems, sync ->
+        AssistantUiState(
+            loginState = login,
+            gmailItems = gmailItems,
+            isSyncing = sync.isSyncing,
+            syncMessage = sync.message,
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.Eagerly,
+        initialValue = AssistantUiState(),
+    )
+
+    init {
+        viewModelScope.launch {
+            authRepository.observeGoogleToken().collect { token ->
+                loginState.update { state ->
+                    state.copy(
+                        hasStoredToken = token != null,
+                        storedScope = token?.scope,
+                        storedExpiresAt = token?.expiresAt,
+                    )
+                }
+            }
+        }
+    }
+
+    fun updateAccessToken(value: String) {
+        loginState.update { it.copy(accessTokenInput = value) }
+    }
+
+    fun updateRefreshToken(value: String) {
+        loginState.update { it.copy(refreshTokenInput = value) }
+    }
+
+    fun updateScope(value: String) {
+        loginState.update { it.copy(scopeInput = value) }
+    }
+
+    fun updateExpiresAt(value: String) {
+        loginState.update { it.copy(expiresAtInput = value) }
+    }
+
+    fun saveToken() {
+        val state = loginState.value
+        val access = state.accessTokenInput.trim()
+        if (access.isEmpty()) {
+            loginState.update { it.copy(statusMessage = "액세스 토큰을 입력해 주세요.") }
+            return
+        }
+        val expiresAt = state.expiresAtInput.trim().takeIf { it.isNotEmpty() }?.toLongOrNull()
+        viewModelScope.launch {
+            authRepository.upsertGoogleToken(
+                accessToken = access,
+                refreshToken = state.refreshTokenInput.trim().takeIf { it.isNotEmpty() },
+                scope = state.scopeInput.trim().ifEmpty { DEFAULT_GMAIL_SCOPE },
+                expiresAt = expiresAt,
+            )
+            loginState.update {
+                it.copy(
+                    accessTokenInput = "",
+                    refreshTokenInput = "",
+                    expiresAtInput = expiresAt?.toString() ?: "",
+                    scopeInput = it.scopeInput.ifEmpty { DEFAULT_GMAIL_SCOPE },
+                    statusMessage = "토큰이 저장되었습니다.",
+                )
+            }
+        }
+    }
+
+    fun clearToken() {
+        viewModelScope.launch {
+            authRepository.clearGoogleToken()
+            loginState.update {
+                it.copy(
+                    statusMessage = "저장된 토큰 정보를 삭제했습니다.",
+                )
+            }
+        }
+    }
+
+    fun syncGmail() {
+        viewModelScope.launch {
+            syncState.value = SyncState(isSyncing = true, message = null)
+            val token = authRepository.getGoogleToken()
+            if (token?.accessToken.isNullOrBlank()) {
+                syncState.value = SyncState(
+                    isSyncing = false,
+                    message = "저장된 토큰이 없어 Gmail을 동기화할 수 없습니다.",
+                )
+                return@launch
+            }
+            when (val result = gmailRepository.syncRecentMessages(token!!.accessToken)) {
+                is GmailSyncResult.Success -> {
+                    syncState.value = SyncState(
+                        isSyncing = false,
+                        message = "${result.upsertedCount}개의 메시지를 동기화했습니다.",
+                    )
+                }
+                is GmailSyncResult.Unauthorized -> {
+                    syncState.value = SyncState(
+                        isSyncing = false,
+                        message = "토큰이 만료되었거나 권한이 없습니다. 다시 로그인해 주세요.",
+                    )
+                }
+                is GmailSyncResult.NetworkError -> {
+                    syncState.value = SyncState(
+                        isSyncing = false,
+                        message = "네트워크 오류: ${result.message}",
+                    )
+                }
+                GmailSyncResult.MissingToken -> {
+                    syncState.value = SyncState(
+                        isSyncing = false,
+                        message = "저장된 토큰이 없어 Gmail을 동기화할 수 없습니다.",
+                    )
+                }
+            }
+        }
+    }
+
+    fun consumeStatusMessage() {
+        loginState.update { it.copy(statusMessage = null) }
+        syncState.update { it.copy(message = null) }
+    }
+}
+
+data class AssistantUiState(
+    val loginState: LoginUiState = LoginUiState(),
+    val gmailItems: List<IngestItem> = emptyList(),
+    val isSyncing: Boolean = false,
+    val syncMessage: String? = null,
+)
+
+data class LoginUiState(
+    val accessTokenInput: String = "",
+    val refreshTokenInput: String = "",
+    val scopeInput: String = DEFAULT_GMAIL_SCOPE,
+    val expiresAtInput: String = "",
+    val hasStoredToken: Boolean = false,
+    val storedScope: String? = null,
+    val storedExpiresAt: Long? = null,
+    val statusMessage: String? = null,
+)
+
+data class SyncState(
+    val isSyncing: Boolean = false,
+    val message: String? = null,
+)

--- a/app/src/main/java/com/example/agent_app/ui/theme/Color.kt
+++ b/app/src/main/java/com/example/agent_app/ui/theme/Color.kt
@@ -1,0 +1,11 @@
+package com.example.agent_app.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+val Purple80 = Color(0xFFD0BCFF)
+val PurpleGrey80 = Color(0xFFCCC2DC)
+val Pink80 = Color(0xFFEFB8C8)
+
+val Purple40 = Color(0xFF6650a4)
+val PurpleGrey40 = Color(0xFF625b71)
+val Pink40 = Color(0xFF7D5260)

--- a/app/src/main/java/com/example/agent_app/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/agent_app/ui/theme/Theme.kt
@@ -1,0 +1,59 @@
+package com.example.agent_app.ui.theme
+
+import android.app.Activity
+import android.os.Build
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowCompat
+
+private val DarkColorScheme = darkColorScheme(
+    primary = Purple80,
+    secondary = PurpleGrey80,
+    tertiary = Pink80,
+)
+
+private val LightColorScheme = lightColorScheme(
+    primary = Purple40,
+    secondary = PurpleGrey40,
+    tertiary = Pink40,
+)
+
+@Composable
+fun AgentAppTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    dynamicColor: Boolean = true,
+    content: @Composable () -> Unit,
+) {
+    val colorScheme = when {
+        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+            val context = LocalContext.current
+            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+        }
+        darkTheme -> DarkColorScheme
+        else -> LightColorScheme
+    }
+
+    val view = LocalView.current
+    if (!view.isInEditMode) {
+        SideEffect {
+            val window = (view.context as Activity).window
+            window.statusBarColor = colorScheme.primary.toArgb()
+            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = !darkTheme
+        }
+    }
+
+    MaterialTheme(
+        colorScheme = colorScheme,
+        typography = Typography,
+        content = content,
+    )
+}

--- a/app/src/main/java/com/example/agent_app/ui/theme/Type.kt
+++ b/app/src/main/java/com/example/agent_app/ui/theme/Type.kt
@@ -1,0 +1,5 @@
+package com.example.agent_app.ui.theme
+
+import androidx.compose.material3.Typography
+
+val Typography = Typography()

--- a/app/src/main/java/com/example/agent_app/util/TimeFormatter.kt
+++ b/app/src/main/java/com/example/agent_app/util/TimeFormatter.kt
@@ -1,0 +1,13 @@
+package com.example.agent_app.util
+
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+object TimeFormatter {
+    private val formatter: DateTimeFormatter =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm").withZone(ZoneId.systemDefault())
+
+    fun format(timestampMillis: Long): String =
+        formatter.format(Instant.ofEpochMilli(timestampMillis))
+}

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,16 +1,4 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.Agent_App" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
-        <!-- Primary brand color. -->
-        <item name="colorPrimary">@color/purple_200</item>
-        <item name="colorPrimaryVariant">@color/purple_700</item>
-        <item name="colorOnPrimary">@color/black</item>
-        <!-- Secondary brand color. -->
-        <item name="colorSecondary">@color/teal_200</item>
-        <item name="colorSecondaryVariant">@color/teal_200</item>
-        <item name="colorOnSecondary">@color/black</item>
-        <!-- Status bar color. -->
-        <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
-        <!-- Customize your theme here. -->
-    </style>
+    <style name="Theme.Agent_App" parent="Theme.Material3.DayNight.NoActionBar" />
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,16 +1,4 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.Agent_App" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
-        <!-- Primary brand color. -->
-        <item name="colorPrimary">@color/purple_500</item>
-        <item name="colorPrimaryVariant">@color/purple_700</item>
-        <item name="colorOnPrimary">@color/white</item>
-        <!-- Secondary brand color. -->
-        <item name="colorSecondary">@color/teal_200</item>
-        <item name="colorSecondaryVariant">@color/teal_700</item>
-        <item name="colorOnSecondary">@color/black</item>
-        <!-- Status bar color. -->
-        <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
-        <!-- Customize your theme here. -->
-    </style>
+    <style name="Theme.Agent_App" parent="Theme.Material3.DayNight.NoActionBar" />
 </resources>

--- a/app/src/test/java/com/example/agent_app/data/repo/GmailRepositoryTest.kt
+++ b/app/src/test/java/com/example/agent_app/data/repo/GmailRepositoryTest.kt
@@ -1,0 +1,148 @@
+package com.example.agent_app.data.repo
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.example.agent_app.data.db.AppDatabase
+import com.example.agent_app.gmail.GmailApi
+import com.example.agent_app.gmail.GmailHeader
+import com.example.agent_app.gmail.GmailMessage
+import com.example.agent_app.gmail.GmailMessageListResponse
+import com.example.agent_app.gmail.GmailMessageReference
+import com.example.agent_app.gmail.GmailPayload
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import retrofit2.HttpException
+import retrofit2.Response
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GmailRepositoryTest {
+
+    private lateinit var database: AppDatabase
+    private lateinit var repository: GmailRepository
+    private lateinit var fakeApi: FakeGmailApi
+
+    @Before
+    fun setUp() {
+        val context: Context = ApplicationProvider.getApplicationContext()
+        database = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        fakeApi = FakeGmailApi()
+        repository = GmailRepository(fakeApi, IngestRepository(database.ingestItemDao()))
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test
+    fun syncRecentMessages_insertsMessagesIntoDatabase() = runTest {
+        val now = System.currentTimeMillis()
+        val messages = listOf(
+            gmailMessage(
+                id = "m1",
+                subject = "Welcome",
+                snippet = "환영합니다",
+                timestamp = now,
+            ),
+            gmailMessage(
+                id = "m2",
+                subject = "Invoice",
+                snippet = "청구서를 확인하세요",
+                timestamp = now - 1_000L,
+            ),
+        )
+        fakeApi.messages = messages
+
+        val result = repository.syncRecentMessages(accessToken = "token")
+
+        assertTrue(result is GmailSyncResult.Success)
+        val dao = database.ingestItemDao()
+        val stored = dao.getById("m1")
+        assertNotNull(stored)
+        assertEquals("Welcome", stored?.title)
+        assertEquals("gmail", stored?.source)
+    }
+
+    @Test
+    fun syncRecentMessages_returnsUnauthorizedOn401() = runTest {
+        fakeApi.throwUnauthorized = true
+
+        val result = repository.syncRecentMessages(accessToken = "token")
+
+        assertTrue(result is GmailSyncResult.Unauthorized)
+    }
+
+    private class FakeGmailApi : GmailApi {
+        var messages: List<GmailMessage> = emptyList()
+        var throwUnauthorized: Boolean = false
+
+        override suspend fun listMessages(
+            authorization: String,
+            userId: String,
+            maxResults: Int,
+            query: String?,
+            pageToken: String?,
+            includeSpamTrash: Boolean,
+        ): GmailMessageListResponse {
+            if (throwUnauthorized) throw unauthorizedException()
+            return GmailMessageListResponse(
+                messages = messages.map { GmailMessageReference(id = it.id, threadId = it.threadId) },
+            )
+        }
+
+        override suspend fun getMessage(
+            authorization: String,
+            userId: String,
+            messageId: String,
+            format: String,
+            metadataHeaders: List<String>,
+        ): GmailMessage {
+            if (throwUnauthorized) throw unauthorizedException()
+            return messages.first { it.id == messageId }
+        }
+
+        private fun unauthorizedException(): HttpException {
+            val response = Response.error<String>(
+                401,
+                "{}".toResponseBody("application/json".toMediaType()),
+            )
+            return HttpException(response)
+        }
+    }
+
+    private fun gmailMessage(
+        id: String,
+        subject: String,
+        snippet: String,
+        timestamp: Long,
+    ): GmailMessage {
+        val formatter = DateTimeFormatter.RFC_1123_DATE_TIME.withZone(ZoneId.of("UTC"))
+        return GmailMessage(
+            id = id,
+            threadId = "thread_$id",
+            snippet = snippet,
+            labelIds = listOf("INBOX"),
+            internalDate = timestamp.toString(),
+            payload = GmailPayload(
+                headers = listOf(
+                    GmailHeader(name = "Subject", value = subject),
+                    GmailHeader(name = "Date", value = formatter.format(Instant.ofEpochMilli(timestamp))),
+                ),
+            ),
+        )
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,16 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath("org.jetbrains.kotlin:kotlin-serialization:2.0.20")
+    }
+}
+
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.ksp) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,16 @@ room = "2.6.1"
 coroutines = "1.8.1"
 androidxTestCore = "1.6.1"
 composeBom = "2024.09.00"
+composeCompiler = "1.5.15"
+activityCompose = "1.9.2"
+lifecycle = "2.8.5"
+retrofit = "2.9.0"
+okhttp = "4.12.0"
+kotlinxSerialization = "1.6.3"
+retrofitKotlinxSerialization = "1.0.0"
+securityCrypto = "1.1.0-alpha06"
+recyclerview = "1.3.2"
+coordinatorlayout = "1.2.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -27,6 +37,28 @@ androidx-room-testing = { group = "androidx.room", name = "room-testing", versio
 androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidxTestCore" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
+androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }
+androidx-compose-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
+androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
+androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
+androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
+androidx-activity-ktx = { group = "androidx.activity", name = "activity-ktx", version.ref = "activityCompose" }
+androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
+androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycle" }
+androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycle" }
+androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycle" }
+retrofit-core = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
+retrofit-kotlinx-serialization = { group = "com.jakewharton.retrofit", name = "retrofit2-kotlinx-serialization-converter", version.ref = "retrofitKotlinxSerialization" }
+okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
+okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
+androidx-security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "securityCrypto" }
+androidx-recyclerview = { group = "androidx.recyclerview", name = "recyclerview", version.ref = "recyclerview" }
+androidx-coordinatorlayout = { group = "androidx.coordinatorlayout", name = "coordinatorlayout", version.ref = "coordinatorlayout" }
+androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- replace the legacy view-binding activity with a Jetpack Compose home screen that drives login inputs and Gmail inbox rendering
- switch the Gmail Retrofit client to kotlinx-serialization with annotated models and a converter-backed service factory
- enable Compose/tooling dependencies, configure the serialization compiler plugin, and document the updated Phase 3 workflow in the README

## Testing
- ./gradlew test *(fails: HTTP 403 when downloading org.jetbrains.kotlin:kotlin-serialization:2.0.20 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d93879e2e48320966fb72d9971d633