### PR TITLE
feat: implement context-aware chat pipeline

### DIFF
--- a/app/src/main/java/com/example/agent_app/data/chat/ChatGatewayImpl.kt
+++ b/app/src/main/java/com/example/agent_app/data/chat/ChatGatewayImpl.kt
@@ -1,0 +1,27 @@
+package com.example.agent_app.data.chat
+
+import com.example.agent_app.data.search.HybridSearchEngine
+import com.example.agent_app.domain.chat.gateway.ChatGateway
+import com.example.agent_app.domain.chat.model.ChatContextItem
+import com.example.agent_app.domain.chat.model.ChatMessage
+import com.example.agent_app.domain.chat.model.QueryFilters
+import com.example.agent_app.openai.OpenAiClient
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class ChatGatewayImpl(
+    private val hybridSearchEngine: HybridSearchEngine,
+    private val openAiClient: OpenAiClient,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : ChatGateway {
+    override suspend fun fetchContext(
+        question: String,
+        filters: QueryFilters,
+        limit: Int,
+    ): List<ChatContextItem> = hybridSearchEngine.search(question, filters, limit)
+
+    override suspend fun requestChatCompletion(messages: List<ChatMessage>): ChatMessage = withContext(dispatcher) {
+        openAiClient.createChatCompletion(messages)
+    }
+}

--- a/app/src/main/java/com/example/agent_app/data/dao/EmbeddingDao.kt
+++ b/app/src/main/java/com/example/agent_app/data/dao/EmbeddingDao.kt
@@ -1,0 +1,19 @@
+package com.example.agent_app.data.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.example.agent_app.data.entity.IngestItemEmbedding
+
+@Dao
+interface EmbeddingDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(embedding: IngestItemEmbedding)
+
+    @Query("SELECT * FROM ingest_item_embeddings WHERE item_id IN (:ids)")
+    suspend fun getEmbeddings(ids: List<String>): List<IngestItemEmbedding>
+
+    @Query("DELETE FROM ingest_item_embeddings WHERE item_id = :id")
+    suspend fun deleteById(id: String)
+}

--- a/app/src/main/java/com/example/agent_app/data/dao/IngestItemDao.kt
+++ b/app/src/main/java/com/example/agent_app/data/dao/IngestItemDao.kt
@@ -31,9 +31,31 @@ interface IngestItemDao {
     
     @Query("SELECT * FROM ingest_items WHERE source = :source ORDER BY timestamp DESC")
     suspend fun getBySource(source: String): List<IngestItem>
-    
+
     @Query("SELECT * FROM ingest_items WHERE source = :source AND type = :type ORDER BY timestamp DESC")
     suspend fun getBySourceAndType(source: String, type: String): List<IngestItem>
+
+    @Query(
+        "SELECT * FROM ingest_items WHERE (" +
+            ":start IS NULL OR timestamp >= :start) " +
+            "AND (:end IS NULL OR timestamp <= :end) " +
+            "AND (:source IS NULL OR source = :source) " +
+            "ORDER BY timestamp DESC LIMIT :limit"
+    )
+    suspend fun filterForSearch(
+        start: Long?,
+        end: Long?,
+        source: String?,
+        limit: Int,
+    ): List<IngestItem>
+
+    @Query(
+        "SELECT * FROM ingest_items WHERE rowid IN (" +
+            "SELECT rowid FROM ingest_items_fts " +
+            "WHERE ingest_items_fts MATCH :query LIMIT :limit" +
+            ")"
+    )
+    suspend fun searchByFullText(query: String, limit: Int): List<IngestItem>
 
     @Query(
         "SELECT * FROM ingest_items WHERE (:start IS NULL OR timestamp >= :start) " +

--- a/app/src/main/java/com/example/agent_app/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/example/agent_app/data/db/AppDatabase.kt
@@ -6,6 +6,7 @@ import androidx.room.Room
 import androidx.room.RoomDatabase
 import com.example.agent_app.data.dao.AuthTokenDao
 import com.example.agent_app.data.dao.ContactDao
+import com.example.agent_app.data.dao.EmbeddingDao
 import com.example.agent_app.data.dao.EventDao
 import com.example.agent_app.data.dao.EventTypeDao
 import com.example.agent_app.data.dao.IngestItemDao
@@ -19,6 +20,8 @@ import com.example.agent_app.data.entity.EventDetail
 import com.example.agent_app.data.entity.EventNotification
 import com.example.agent_app.data.entity.EventType
 import com.example.agent_app.data.entity.IngestItem
+import com.example.agent_app.data.entity.IngestItemEmbedding
+import com.example.agent_app.data.entity.IngestItemFts
 import com.example.agent_app.data.entity.Note
 import com.example.agent_app.data.entity.User
 
@@ -33,8 +36,10 @@ import com.example.agent_app.data.entity.User
         EventNotification::class,
         AuthToken::class,
         IngestItem::class,
+        IngestItemFts::class,
+        IngestItemEmbedding::class,
     ],
-    version = 1,
+    version = 2,
     exportSchema = true,
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -46,6 +51,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun eventDao(): EventDao
     abstract fun authTokenDao(): AuthTokenDao
     abstract fun ingestItemDao(): IngestItemDao
+    abstract fun embeddingDao(): EmbeddingDao
 
     companion object {
         private const val DATABASE_NAME = "assistant.db"

--- a/app/src/main/java/com/example/agent_app/data/db/migrations/DatabaseMigrations.kt
+++ b/app/src/main/java/com/example/agent_app/data/db/migrations/DatabaseMigrations.kt
@@ -1,7 +1,26 @@
 package com.example.agent_app.data.db.migrations
 
 import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 
 object DatabaseMigrations {
-    val ALL: Array<Migration> = emptyArray()
+    private val MIGRATION_1_2 = object : Migration(1, 2) {
+        override fun migrate(database: SupportSQLiteDatabase) {
+            database.execSQL(
+                "CREATE VIRTUAL TABLE IF NOT EXISTS `ingest_items_fts` USING FTS4(`title`, `body`, content=`ingest_items`)"
+            )
+            database.execSQL(
+                "CREATE TABLE IF NOT EXISTS `ingest_item_embeddings` (" +
+                    "`item_id` TEXT NOT NULL, " +
+                    "`vector` BLOB NOT NULL, " +
+                    "`dimension` INTEGER NOT NULL, " +
+                    "`updated_at` INTEGER NOT NULL, " +
+                    "PRIMARY KEY(`item_id`)" +
+                    ")"
+            )
+            database.execSQL("INSERT INTO ingest_items_fts(ingest_items_fts) VALUES('rebuild')")
+        }
+    }
+
+    val ALL: Array<Migration> = arrayOf(MIGRATION_1_2)
 }

--- a/app/src/main/java/com/example/agent_app/data/entity/IngestItemEmbedding.kt
+++ b/app/src/main/java/com/example/agent_app/data/entity/IngestItemEmbedding.kt
@@ -1,0 +1,16 @@
+package com.example.agent_app.data.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "ingest_item_embeddings")
+data class IngestItemEmbedding(
+    @PrimaryKey
+    @ColumnInfo(name = "item_id")
+    val itemId: String,
+    val vector: ByteArray,
+    val dimension: Int,
+    @ColumnInfo(name = "updated_at")
+    val updatedAt: Long,
+)

--- a/app/src/main/java/com/example/agent_app/data/entity/IngestItemFts.kt
+++ b/app/src/main/java/com/example/agent_app/data/entity/IngestItemFts.kt
@@ -1,0 +1,11 @@
+package com.example.agent_app.data.entity
+
+import androidx.room.Entity
+import androidx.room.Fts4
+
+@Fts4(contentEntity = IngestItem::class)
+@Entity(tableName = "ingest_items_fts")
+data class IngestItemFts(
+    val title: String?,
+    val body: String?,
+)

--- a/app/src/main/java/com/example/agent_app/data/repo/IngestRepository.kt
+++ b/app/src/main/java/com/example/agent_app/data/repo/IngestRepository.kt
@@ -2,6 +2,8 @@ package com.example.agent_app.data.repo
 
 import com.example.agent_app.data.dao.IngestItemDao
 import com.example.agent_app.data.entity.IngestItem
+import com.example.agent_app.data.search.EmbeddingGenerator
+import com.example.agent_app.data.search.EmbeddingStore
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -10,15 +12,24 @@ import kotlinx.coroutines.withContext
 class IngestRepository(
     private val dao: IngestItemDao,
     private val parser: IngestItemParser = IngestItemParser(),
+    private val embeddingStore: EmbeddingStore? = null,
+    private val embeddingGenerator: EmbeddingGenerator = EmbeddingGenerator(),
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
     suspend fun upsert(item: IngestItem) = withContext(dispatcher) {
         val enriched = parser.enrich(item)
         dao.upsert(enriched)
+        embeddingStore?.let { store ->
+            val text = listOfNotNull(enriched.title, enriched.body).joinToString("\n").trim()
+            if (text.isNotEmpty()) {
+                val embedding = embeddingGenerator.generateEmbedding(text)
+                store.saveEmbedding(enriched.id, embedding)
+            }
+        }
     }
 
     fun observeBySource(source: String): Flow<List<IngestItem>> = dao.observeBySource(source)
-    
+
     suspend fun clearAll() = withContext(dispatcher) {
         dao.clearAll()
     }

--- a/app/src/main/java/com/example/agent_app/data/search/EmbeddingGenerator.kt
+++ b/app/src/main/java/com/example/agent_app/data/search/EmbeddingGenerator.kt
@@ -1,0 +1,62 @@
+package com.example.agent_app.data.search
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.security.MessageDigest
+import kotlin.math.sqrt
+
+/**
+ * Generates simple deterministic embeddings for text using hashing.
+ * This is a lightweight placeholder that can be swapped for a real model later.
+ */
+class EmbeddingGenerator(
+    private val dimension: Int = DEFAULT_DIMENSION,
+) {
+    fun generateEmbedding(text: String): FloatArray {
+        if (text.isBlank()) {
+            return FloatArray(dimension)
+        }
+        val tokens = tokenize(text)
+        val vector = FloatArray(dimension)
+        val digest = MessageDigest.getInstance("SHA-256")
+        tokens.forEach { token ->
+            val hash = digest.digest(token.toByteArray())
+            val buffer = ByteBuffer.wrap(hash).order(ByteOrder.BIG_ENDIAN)
+            val ints = IntArray(hash.size / Int.SIZE_BYTES) { idx ->
+                buffer.getInt(idx * Int.SIZE_BYTES)
+            }
+            repeat(dimension) { index ->
+                val value = ints[index % ints.size]
+                vector[index] += (value % 1000) / 1000f
+            }
+        }
+        return normalize(vector)
+    }
+
+    private fun normalize(vector: FloatArray): FloatArray {
+        var sumSquares = 0.0
+        vector.forEach { value -> sumSquares += value * value }
+        val magnitude = sqrt(sumSquares)
+        if (magnitude == 0.0) {
+            return vector
+        }
+        for (i in vector.indices) {
+            vector[i] = (vector[i] / magnitude).toFloat()
+        }
+        return vector
+    }
+
+    fun dimension(): Int = dimension
+
+    private fun tokenize(text: String): List<String> = text
+        .lowercase()
+        .split(" ", "\n", "\t", ",", ".", "?", "!", ":", ";")
+        .mapNotNull { token ->
+            val trimmed = token.trim()
+            trimmed.takeIf { it.length >= 2 }
+        }
+
+    companion object {
+        private const val DEFAULT_DIMENSION = 64
+    }
+}

--- a/app/src/main/java/com/example/agent_app/data/search/EmbeddingStore.kt
+++ b/app/src/main/java/com/example/agent_app/data/search/EmbeddingStore.kt
@@ -1,0 +1,49 @@
+package com.example.agent_app.data.search
+
+import com.example.agent_app.data.dao.EmbeddingDao
+import com.example.agent_app.data.entity.IngestItemEmbedding
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+class EmbeddingStore(
+    private val embeddingDao: EmbeddingDao,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) {
+    suspend fun getEmbeddings(ids: List<String>): Map<String, FloatArray> = withContext(dispatcher) {
+        if (ids.isEmpty()) return@withContext emptyMap()
+        embeddingDao.getEmbeddings(ids).associate { embedding ->
+            embedding.itemId to embedding.vector.toFloatArray(embedding.dimension)
+        }
+    }
+
+    suspend fun saveEmbedding(itemId: String, vector: FloatArray) = withContext(dispatcher) {
+        val bytes = vector.toByteArray()
+        embeddingDao.upsert(
+            IngestItemEmbedding(
+                itemId = itemId,
+                vector = bytes,
+                dimension = vector.size,
+                updatedAt = System.currentTimeMillis(),
+            )
+        )
+    }
+
+    private fun ByteArray.toFloatArray(expectedDimension: Int): FloatArray {
+        if (isEmpty()) return FloatArray(expectedDimension)
+        val buffer = ByteBuffer.wrap(this).order(ByteOrder.LITTLE_ENDIAN)
+        val floats = FloatArray(expectedDimension)
+        for (index in 0 until expectedDimension) {
+            floats[index] = if (buffer.remaining() >= Float.SIZE_BYTES) buffer.float else 0f
+        }
+        return floats
+    }
+
+    private fun FloatArray.toByteArray(): ByteArray {
+        val buffer = ByteBuffer.allocate(size * Float.SIZE_BYTES).order(ByteOrder.LITTLE_ENDIAN)
+        forEach { value -> buffer.putFloat(value) }
+        return buffer.array()
+    }
+}

--- a/app/src/main/java/com/example/agent_app/data/search/HybridSearchEngine.kt
+++ b/app/src/main/java/com/example/agent_app/data/search/HybridSearchEngine.kt
@@ -1,0 +1,165 @@
+package com.example.agent_app.data.search
+
+import android.database.sqlite.SQLiteException
+import com.example.agent_app.data.dao.IngestItemDao
+import com.example.agent_app.data.entity.IngestItem
+import com.example.agent_app.domain.chat.model.ChatContextItem
+import com.example.agent_app.domain.chat.model.QueryFilters
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlin.math.max
+import kotlin.math.min
+
+class HybridSearchEngine(
+    private val ingestItemDao: IngestItemDao,
+    private val embeddingStore: EmbeddingStore,
+    private val embeddingGenerator: EmbeddingGenerator,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) {
+    suspend fun search(
+        question: String,
+        filters: QueryFilters,
+        limit: Int = DEFAULT_LIMIT,
+    ): List<ChatContextItem> = withContext(dispatcher) {
+        val sanitizedQuestion = question.trim()
+        val keywordCandidates = runCatching {
+            if (sanitizedQuestion.isBlank()) emptyList() else {
+                val query = buildMatchQuery(filters.keywords.ifEmpty { extractKeywords(sanitizedQuestion) })
+                if (query.isBlank()) emptyList() else ingestItemDao.searchByFullText(query, limit * 3)
+            }
+        }.recoverCatching { throwable ->
+            if (throwable is SQLiteException) emptyList() else throw throwable
+        }.getOrDefault(emptyList())
+
+        val structuredCandidates = ingestItemDao.filterForSearch(
+            start = filters.startTimeMillis,
+            end = filters.endTimeMillis,
+            source = filters.source,
+            limit = limit * 4,
+        )
+
+        val combined = (keywordCandidates + structuredCandidates)
+            .associateBy { it.id }
+            .values
+            .toList()
+        if (combined.isEmpty()) {
+            return@withContext emptyList()
+        }
+
+        val queryEmbedding = embeddingGenerator.generateEmbedding(sanitizedQuestion)
+        val cachedEmbeddings = embeddingStore.getEmbeddings(combined.map(IngestItem::id))
+
+        val scored = combined.mapIndexed { index, item ->
+            val keywords = filters.keywords.ifEmpty { extractKeywords(sanitizedQuestion) }
+            val keywordScore = keywordRelevance(item, keywords, index)
+            val itemEmbedding = cachedEmbeddings[item.id] ?: buildEmbeddingFor(item).also {
+                embeddingStore.saveEmbedding(item.id, it)
+            }
+            val vectorScore = cosineSimilarity(queryEmbedding, itemEmbedding)
+            val recency = recencyBoost(item, filters)
+            val finalScore = keywordScore * 0.5 + vectorScore * 0.4 + recency * 0.1
+            Pair(item, finalScore)
+        }
+
+        scored
+            .sortedByDescending { it.second }
+            .take(limit)
+            .mapIndexed { position, (item, score) ->
+                ChatContextItem(
+                    itemId = item.id,
+                    title = item.title.orEmpty(),
+                    body = item.body.orEmpty(),
+                    source = item.source,
+                    timestamp = item.timestamp,
+                    relevance = score,
+                    position = position + 1,
+                )
+            }
+    }
+
+    private suspend fun buildEmbeddingFor(item: IngestItem): FloatArray = withContext(dispatcher) {
+        val text = listOfNotNull(item.title, item.body).joinToString("\n").trim()
+        embeddingGenerator.generateEmbedding(text)
+    }
+
+    private fun keywordRelevance(item: IngestItem, keywords: List<String>, index: Int): Double {
+        if (keywords.isEmpty()) return 0.2
+        val haystack = listOfNotNull(item.title, item.body)
+            .joinToString(" ")
+            .lowercase()
+        var matches = 0
+        keywords.forEach { keyword ->
+            if (haystack.contains(keyword.lowercase())) {
+                matches += 1
+            }
+        }
+        if (matches == 0) return max(0.1, 0.5 - index * 0.05)
+        val ratio = matches.toDouble() / keywords.size
+        return min(1.0, 0.5 + ratio * 0.5)
+    }
+
+    private fun recencyBoost(item: IngestItem, filters: QueryFilters): Double {
+        val targetStart = filters.startTimeMillis ?: return 0.2
+        val targetEnd = filters.endTimeMillis ?: return 0.2
+        if (item.timestamp in targetStart..targetEnd) {
+            return 0.6
+        }
+        val distance = min(
+            kotlin.math.abs(item.timestamp - targetStart),
+            kotlin.math.abs(item.timestamp - targetEnd)
+        )
+        return when {
+            distance < DAY_MILLIS -> 0.45
+            distance < 3 * DAY_MILLIS -> 0.35
+            distance < 7 * DAY_MILLIS -> 0.2
+            else -> 0.05
+        }
+    }
+
+    private fun cosineSimilarity(a: FloatArray, b: FloatArray): Double {
+        if (a.isEmpty() || b.isEmpty() || a.size != b.size) return 0.0
+        var dot = 0.0
+        var magA = 0.0
+        var magB = 0.0
+        for (index in a.indices) {
+            val va = a[index].toDouble()
+            val vb = b[index].toDouble()
+            dot += va * vb
+            magA += va * va
+            magB += vb * vb
+        }
+        if (magA == 0.0 || magB == 0.0) return 0.0
+        return dot / (kotlin.math.sqrt(magA) * kotlin.math.sqrt(magB))
+    }
+
+    private fun buildMatchQuery(keywords: List<String>): String {
+        if (keywords.isEmpty()) return ""
+        return keywords.joinToString(" ") { keyword ->
+            val sanitized = keyword
+                .replace('"', ' ')
+                .replace("'", " ")
+                .trim()
+            if (sanitized.isBlank()) "" else "\"$sanitized*\""
+        }.trim()
+    }
+
+    private fun extractKeywords(text: String): List<String> = text
+        .lowercase()
+        .split(" ", "\n", "\t", ",", ".", "?", "!", ":", ";")
+        .mapNotNull { token ->
+            val trimmed = token.trim()
+            trimmed.takeIf { it.length >= 2 && it !in STOPWORDS }
+        }
+        .take(6)
+
+    companion object {
+        private const val DEFAULT_LIMIT = 5
+        private const val DAY_MILLIS = 24 * 60 * 60 * 1000L
+
+        private val STOPWORDS = setOf(
+            "the", "is", "are", "and", "or", "a", "an", "what", "when", "where", "who", "how",
+            "please", "tell", "show", "about", "me", "of", "to", "for", "in"
+        )
+    }
+}

--- a/app/src/main/java/com/example/agent_app/di/AppContainer.kt
+++ b/app/src/main/java/com/example/agent_app/di/AppContainer.kt
@@ -1,0 +1,79 @@
+package com.example.agent_app.di
+
+import android.content.Context
+import com.example.agent_app.ai.OpenAIClassifier
+import com.example.agent_app.data.chat.ChatGatewayImpl
+import com.example.agent_app.data.db.AppDatabase
+import com.example.agent_app.data.repo.AuthRepository
+import com.example.agent_app.data.repo.ClassifiedDataRepository
+import com.example.agent_app.data.repo.GmailRepository
+import com.example.agent_app.data.repo.IngestItemParser
+import com.example.agent_app.data.repo.IngestRepository
+import com.example.agent_app.data.search.EmbeddingGenerator
+import com.example.agent_app.data.search.EmbeddingStore
+import com.example.agent_app.data.search.HybridSearchEngine
+import com.example.agent_app.domain.chat.gateway.ChatGateway
+import com.example.agent_app.domain.chat.usecase.ExecuteChatUseCase
+import com.example.agent_app.domain.chat.usecase.ProcessUserQueryUseCase
+import com.example.agent_app.domain.chat.usecase.PromptBuilder
+import com.example.agent_app.gmail.GmailServiceFactory
+import com.example.agent_app.openai.OpenAiClient
+import com.example.agent_app.openai.PromptBuilderImpl
+
+class AppContainer(context: Context) {
+    val database: AppDatabase = AppDatabase.build(context)
+
+    private val embeddingStore = EmbeddingStore(database.embeddingDao())
+    private val embeddingGenerator = EmbeddingGenerator()
+
+    val authRepository: AuthRepository = AuthRepository(database.authTokenDao())
+    val ingestRepository: IngestRepository = IngestRepository(
+        dao = database.ingestItemDao(),
+        parser = IngestItemParser(),
+        embeddingStore = embeddingStore,
+        embeddingGenerator = embeddingGenerator,
+    )
+
+    private val openAIClassifier = OpenAIClassifier()
+
+    val classifiedDataRepository: ClassifiedDataRepository = ClassifiedDataRepository(
+        openAIClassifier = openAIClassifier,
+        contactDao = database.contactDao(),
+        eventDao = database.eventDao(),
+        eventTypeDao = database.eventTypeDao(),
+        noteDao = database.noteDao(),
+        ingestRepository = ingestRepository,
+    )
+
+    val gmailRepository: GmailRepository = GmailRepository(
+        api = GmailServiceFactory.create(),
+        ingestRepository = ingestRepository,
+        classifiedDataRepository = classifiedDataRepository,
+    )
+
+    private val hybridSearchEngine = HybridSearchEngine(
+        ingestItemDao = database.ingestItemDao(),
+        embeddingStore = embeddingStore,
+        embeddingGenerator = embeddingGenerator,
+    )
+
+    private val promptBuilder: PromptBuilder = PromptBuilderImpl()
+    private val chatGateway: ChatGateway = ChatGatewayImpl(
+        hybridSearchEngine = hybridSearchEngine,
+        openAiClient = OpenAiClient(),
+    )
+
+    private val processUserQueryUseCase = ProcessUserQueryUseCase()
+
+    val executeChatUseCase: ExecuteChatUseCase = ExecuteChatUseCase(
+        processUserQueryUseCase = processUserQueryUseCase,
+        chatGateway = chatGateway,
+        promptBuilder = promptBuilder,
+    )
+
+    fun close() {
+        if (database.isOpen) {
+            database.close()
+        }
+    }
+}

--- a/app/src/main/java/com/example/agent_app/domain/chat/gateway/ChatGateway.kt
+++ b/app/src/main/java/com/example/agent_app/domain/chat/gateway/ChatGateway.kt
@@ -1,0 +1,10 @@
+package com.example.agent_app.domain.chat.gateway
+
+import com.example.agent_app.domain.chat.model.ChatContextItem
+import com.example.agent_app.domain.chat.model.ChatMessage
+import com.example.agent_app.domain.chat.model.QueryFilters
+
+interface ChatGateway {
+    suspend fun fetchContext(question: String, filters: QueryFilters, limit: Int = 5): List<ChatContextItem>
+    suspend fun requestChatCompletion(messages: List<ChatMessage>): ChatMessage
+}

--- a/app/src/main/java/com/example/agent_app/domain/chat/model/ChatContextItem.kt
+++ b/app/src/main/java/com/example/agent_app/domain/chat/model/ChatContextItem.kt
@@ -1,0 +1,11 @@
+package com.example.agent_app.domain.chat.model
+
+data class ChatContextItem(
+    val itemId: String,
+    val title: String,
+    val body: String,
+    val source: String,
+    val timestamp: Long,
+    val relevance: Double,
+    val position: Int,
+)

--- a/app/src/main/java/com/example/agent_app/domain/chat/model/ChatMessage.kt
+++ b/app/src/main/java/com/example/agent_app/domain/chat/model/ChatMessage.kt
@@ -1,0 +1,8 @@
+package com.example.agent_app.domain.chat.model
+
+data class ChatMessage(
+    val role: Role,
+    val content: String,
+) {
+    enum class Role { USER, ASSISTANT, SYSTEM }
+}

--- a/app/src/main/java/com/example/agent_app/domain/chat/model/ChatResult.kt
+++ b/app/src/main/java/com/example/agent_app/domain/chat/model/ChatResult.kt
@@ -1,0 +1,8 @@
+package com.example.agent_app.domain.chat.model
+
+data class ChatResult(
+    val question: ChatMessage,
+    val answer: ChatMessage,
+    val contextItems: List<ChatContextItem>,
+    val filters: QueryFilters,
+)

--- a/app/src/main/java/com/example/agent_app/domain/chat/model/QueryFilters.kt
+++ b/app/src/main/java/com/example/agent_app/domain/chat/model/QueryFilters.kt
@@ -1,0 +1,8 @@
+package com.example.agent_app.domain.chat.model
+
+data class QueryFilters(
+    val startTimeMillis: Long? = null,
+    val endTimeMillis: Long? = null,
+    val source: String? = null,
+    val keywords: List<String> = emptyList(),
+)

--- a/app/src/main/java/com/example/agent_app/domain/chat/usecase/ExecuteChatUseCase.kt
+++ b/app/src/main/java/com/example/agent_app/domain/chat/usecase/ExecuteChatUseCase.kt
@@ -1,0 +1,31 @@
+package com.example.agent_app.domain.chat.usecase
+
+import com.example.agent_app.domain.chat.gateway.ChatGateway
+import com.example.agent_app.domain.chat.model.ChatContextItem
+import com.example.agent_app.domain.chat.model.ChatMessage
+import com.example.agent_app.domain.chat.model.ChatResult
+import com.example.agent_app.domain.chat.model.QueryFilters
+
+class ExecuteChatUseCase(
+    private val processUserQueryUseCase: ProcessUserQueryUseCase,
+    private val chatGateway: ChatGateway,
+    private val promptBuilder: PromptBuilder,
+) {
+    suspend operator fun invoke(questionText: String): ChatResult {
+        val question = ChatMessage(ChatMessage.Role.USER, questionText)
+        val filters = processUserQueryUseCase(questionText)
+        val context = chatGateway.fetchContext(questionText, filters)
+        val messages = promptBuilder.buildMessages(question, context)
+        val answer = chatGateway.requestChatCompletion(messages)
+        return ChatResult(
+            question = question,
+            answer = answer,
+            contextItems = context,
+            filters = filters,
+        )
+    }
+}
+
+interface PromptBuilder {
+    fun buildMessages(question: ChatMessage, context: List<ChatContextItem>): List<ChatMessage>
+}

--- a/app/src/main/java/com/example/agent_app/domain/chat/usecase/ProcessUserQueryUseCase.kt
+++ b/app/src/main/java/com/example/agent_app/domain/chat/usecase/ProcessUserQueryUseCase.kt
@@ -1,0 +1,67 @@
+package com.example.agent_app.domain.chat.usecase
+
+import com.example.agent_app.domain.chat.model.QueryFilters
+import com.example.agent_app.util.TimeResolver
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+class ProcessUserQueryUseCase(
+    private val timeResolver: TimeResolverAdapter = TimeResolverAdapter(),
+) {
+    operator fun invoke(rawQuestion: String): QueryFilters {
+        val trimmed = rawQuestion.trim()
+        if (trimmed.isEmpty()) {
+            return QueryFilters()
+        }
+        val resolution = timeResolver.resolve(trimmed)
+        val (start, end) = resolution?.let { windowFor(it.timestampMillis) } ?: (null to null)
+        val keywords = extractKeywords(trimmed)
+        val source = detectSource(trimmed)
+        return QueryFilters(
+            startTimeMillis = start,
+            endTimeMillis = end,
+            source = source,
+            keywords = keywords,
+        )
+    }
+
+    private fun windowFor(center: Long): Pair<Long, Long> {
+        val twelveHours = 12 * 60 * 60 * 1000L
+        return (center - twelveHours) to (center + twelveHours)
+    }
+
+    private fun extractKeywords(text: String): List<String> = text
+        .lowercase()
+        .split(" ", "\n", "\t", ",", ".", "?", "!", ":", ";")
+        .mapNotNull { token ->
+            val trimmed = token.trim()
+            trimmed.takeIf { it.length >= 2 && it !in STOPWORDS }
+        }
+        .distinct()
+        .take(8)
+
+    private fun detectSource(text: String): String? {
+        val lower = text.lowercase()
+        return when {
+            lower.contains("gmail") || lower.contains("email") -> "gmail"
+            lower.contains("sms") -> "sms"
+            lower.contains("ocr") -> "ocr"
+            else -> null
+        }
+    }
+
+    class TimeResolverAdapter(
+        private val zoneId: ZoneId = ZoneId.of("Asia/Seoul"),
+    ) {
+        fun resolve(text: String): TimeResolver.Resolution? = TimeResolver.resolve(text)
+
+        fun now(): ZonedDateTime = ZonedDateTime.now(zoneId)
+    }
+
+    companion object {
+        private val STOPWORDS = setOf(
+            "the", "is", "are", "and", "or", "a", "an", "what", "when", "where", "who", "how",
+            "me", "please", "show", "tell", "about", "최근", "문의", "알려줘", "줘"
+        )
+    }
+}

--- a/app/src/main/java/com/example/agent_app/openai/OpenAiClient.kt
+++ b/app/src/main/java/com/example/agent_app/openai/OpenAiClient.kt
@@ -1,0 +1,103 @@
+package com.example.agent_app.openai
+
+import com.example.agent_app.BuildConfig
+import com.example.agent_app.domain.chat.model.ChatMessage
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.logging.HttpLoggingInterceptor
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+
+class OpenAiClient(
+    private val httpClient: OkHttpClient = defaultClient(),
+    private val json: Json = Json { ignoreUnknownKeys = true },
+    private val model: String = DEFAULT_MODEL,
+) {
+    suspend fun createChatCompletion(messages: List<ChatMessage>): ChatMessage {
+        val apiKey = BuildConfig.OPENAI_API_KEY
+        if (apiKey.isBlank()) {
+            return ChatMessage(
+                role = ChatMessage.Role.ASSISTANT,
+                content = "OpenAI API 키가 설정되어 있지 않아, 로컬 컨텍스트 요약만 제공합니다."
+            )
+        }
+        val payload = ChatCompletionRequest(
+            model = model,
+            messages = messages.map { message ->
+                ChatCompletionMessage(role = message.role.name.lowercase(), content = message.content)
+            },
+            temperature = 0.3,
+            maxTokens = 600,
+        )
+        val body = json.encodeToString(ChatCompletionRequest.serializer(), payload)
+            .toRequestBody("application/json".toMediaType())
+        val request = Request.Builder()
+            .url("https://api.openai.com/v1/chat/completions")
+            .addHeader("Authorization", "Bearer $apiKey")
+            .addHeader("Content-Type", "application/json")
+            .post(body)
+            .build()
+        return try {
+            httpClient.newCall(request).execute().use { response ->
+                val responseBody = response.body?.string()
+                    ?: return fallbackResponse("Empty response from OpenAI")
+                if (!response.isSuccessful) {
+                    return fallbackResponse("OpenAI error: ${response.code}")
+                }
+                val completion = json.decodeFromString(ChatCompletionResponse.serializer(), responseBody)
+                val content = completion.choices.firstOrNull()?.message?.content
+                    ?: return fallbackResponse("OpenAI 응답에 메시지가 없습니다.")
+                ChatMessage(ChatMessage.Role.ASSISTANT, content.trim())
+            }
+        } catch (exception: IOException) {
+            fallbackResponse("네트워크 오류: ${exception.message}")
+        }
+    }
+
+    private fun fallbackResponse(message: String): ChatMessage = ChatMessage(
+        role = ChatMessage.Role.ASSISTANT,
+        content = "$message\n\n컨텍스트 요약을 참고해 주세요."
+    )
+
+    companion object {
+        private const val DEFAULT_MODEL = "gpt-4o-mini"
+
+        private fun defaultClient(): OkHttpClient = OkHttpClient.Builder()
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .addInterceptor(HttpLoggingInterceptor().apply {
+                level = HttpLoggingInterceptor.Level.BASIC
+            })
+            .build()
+    }
+}
+
+@Serializable
+private data class ChatCompletionRequest(
+    val model: String,
+    val messages: List<ChatCompletionMessage>,
+    val temperature: Double,
+    @SerialName("max_tokens")
+    val maxTokens: Int,
+)
+
+@Serializable
+private data class ChatCompletionMessage(
+    val role: String,
+    val content: String,
+)
+
+@Serializable
+private data class ChatCompletionResponse(
+    val choices: List<ChatCompletionChoice>,
+)
+
+@Serializable
+private data class ChatCompletionChoice(
+    val message: ChatCompletionMessage,
+)

--- a/app/src/main/java/com/example/agent_app/openai/PromptBuilderImpl.kt
+++ b/app/src/main/java/com/example/agent_app/openai/PromptBuilderImpl.kt
@@ -1,0 +1,52 @@
+package com.example.agent_app.openai
+
+import com.example.agent_app.domain.chat.model.ChatContextItem
+import com.example.agent_app.domain.chat.model.ChatMessage
+import com.example.agent_app.domain.chat.usecase.PromptBuilder
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+class PromptBuilderImpl : PromptBuilder {
+    override fun buildMessages(
+        question: ChatMessage,
+        context: List<ChatContextItem>,
+    ): List<ChatMessage> {
+        val systemContent = """
+            당신은 사용자의 개인 비서입니다. 아래 제공된 Context 목록만을 근거로 질문에 답변하세요.
+            모르면 모른다고 답하고, 추측하지 마세요. 답변은 한국어로 5문장 이내로 요약해 주세요.
+        """.trimIndent()
+
+        val contextContent = buildString {
+            appendLine("[Context]")
+            if (context.isEmpty()) {
+                appendLine("- 관련 데이터를 찾지 못했습니다.")
+            } else {
+                context.forEach { item ->
+                    appendLine("${item.position}. (${item.source}) ${formatTimestamp(item.timestamp)} - ${item.title}")
+                    appendLine(item.body.take(500))
+                    appendLine("-- relevance: ${"%.2f".format(item.relevance)}")
+                    appendLine()
+                }
+            }
+        }.trim()
+
+        val userContent = buildString {
+            appendLine(contextContent)
+            appendLine()
+            appendLine("[질문]")
+            appendLine(question.content)
+        }
+
+        return listOf(
+            ChatMessage(ChatMessage.Role.SYSTEM, systemContent),
+            ChatMessage(ChatMessage.Role.USER, userContent)
+        )
+    }
+
+    private fun formatTimestamp(timestamp: Long): String {
+        return Instant.ofEpochMilli(timestamp)
+            .atZone(ZoneId.of("Asia/Seoul"))
+            .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"))
+    }
+}

--- a/app/src/main/java/com/example/agent_app/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/agent_app/ui/MainActivity.kt
@@ -6,51 +6,39 @@ import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import com.example.agent_app.data.db.AppDatabase
 import com.example.agent_app.data.repo.AuthRepository
+import com.example.agent_app.data.repo.ClassifiedDataRepository
 import com.example.agent_app.data.repo.GmailRepository
 import com.example.agent_app.data.repo.IngestRepository
-import com.example.agent_app.data.repo.ClassifiedDataRepository
-import com.example.agent_app.ai.OpenAIClassifier
 import com.example.agent_app.data.entity.User
+import com.example.agent_app.di.AppContainer
+import com.example.agent_app.ui.chat.ChatViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import com.example.agent_app.gmail.GmailServiceFactory
 import com.example.agent_app.ui.theme.AgentAppTheme
 
 class MainActivity : ComponentActivity() {
 
-    private val database: AppDatabase by lazy { AppDatabase.build(applicationContext) }
-    private val authRepository: AuthRepository by lazy { AuthRepository(database.authTokenDao()) }
-    private val ingestRepository: IngestRepository by lazy { IngestRepository(database.ingestItemDao()) }
-    private val classifiedDataRepository: ClassifiedDataRepository by lazy {
-        val openAIClassifier = OpenAIClassifier()
-        ClassifiedDataRepository(
-            openAIClassifier = openAIClassifier,
-            contactDao = database.contactDao(),
-            eventDao = database.eventDao(),
-            eventTypeDao = database.eventTypeDao(),
-            noteDao = database.noteDao(),
-            ingestItemDao = database.ingestItemDao()
-        )
-    }
-    
-    private val gmailRepository: GmailRepository by lazy {
-        GmailRepository(
-            api = GmailServiceFactory.create(),
-            ingestRepository = ingestRepository,
-            classifiedDataRepository = classifiedDataRepository,
+    private val appContainer: AppContainer by lazy { AppContainer(applicationContext) }
+
+    private val mainViewModel: MainViewModel by viewModels {
+        MainViewModelFactory(
+            appContainer.authRepository,
+            appContainer.ingestRepository,
+            appContainer.gmailRepository,
+            appContainer.classifiedDataRepository,
         )
     }
 
-    private val viewModel: MainViewModel by viewModels {
-        MainViewModelFactory(authRepository, ingestRepository, gmailRepository, classifiedDataRepository)
+    private val chatViewModel: ChatViewModel by viewModels {
+        ChatViewModelFactory(appContainer.executeChatUseCase)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        
+
+        val database = appContainer.database
         // 기본 사용자 생성
         CoroutineScope(Dispatchers.IO).launch {
             val existingUser = database.userDao().getById(1L)
@@ -64,19 +52,20 @@ class MainActivity : ComponentActivity() {
                 database.userDao().upsert(defaultUser)
             }
         }
-        
+
         setContent {
             AgentAppTheme {
-                AssistantApp(viewModel = viewModel)
+                AssistantApp(
+                    mainViewModel = mainViewModel,
+                    chatViewModel = chatViewModel,
+                )
             }
         }
     }
 
     override fun onDestroy() {
         super.onDestroy()
-        if (database.isOpen) {
-            database.close()
-        }
+        appContainer.close()
     }
 }
 
@@ -92,5 +81,17 @@ private class MainViewModelFactory(
             "Unknown ViewModel class: ${modelClass.name}"
         }
         return MainViewModel(authRepository, ingestRepository, gmailRepository, classifiedDataRepository) as T
+    }
+}
+
+private class ChatViewModelFactory(
+    private val executeChatUseCase: com.example.agent_app.domain.chat.usecase.ExecuteChatUseCase,
+) : ViewModelProvider.Factory {
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        require(modelClass.isAssignableFrom(ChatViewModel::class.java)) {
+            "Unknown ViewModel class: ${modelClass.name}"
+        }
+        return ChatViewModel(executeChatUseCase) as T
     }
 }

--- a/app/src/main/java/com/example/agent_app/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/example/agent_app/ui/chat/ChatScreen.kt
@@ -1,0 +1,193 @@
+package com.example.agent_app.ui.chat
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+@Composable
+fun ChatScreen(
+    viewModel: ChatViewModel,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    var input by rememberSaveable { mutableStateOf("") }
+
+    Box(modifier = modifier.fillMaxSize()) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            ChatHistory(state.entries, modifier = Modifier.weight(1f))
+            ChatInput(
+                value = input,
+                onValueChange = { input = it },
+                onSend = {
+                    viewModel.submit(input)
+                    input = ""
+                },
+                enabled = !state.isProcessing,
+            )
+        }
+        if (state.isProcessing) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Black.copy(alpha = 0.1f)),
+                contentAlignment = Alignment.Center,
+            ) {
+                CircularProgressIndicator()
+            }
+        }
+        if (state.error != null) {
+            AlertDialog(
+                onDismissRequest = viewModel::consumeError,
+                title = { Text("오류") },
+                text = { Text(state.error ?: "") },
+                confirmButton = {
+                    TextButton(onClick = viewModel::consumeError) {
+                        Text("확인")
+                    }
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun ChatHistory(entries: List<ChatThreadEntry>, modifier: Modifier = Modifier) {
+    LazyColumn(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        items(entries) { entry ->
+            ChatEntryCard(entry)
+        }
+    }
+}
+
+@Composable
+private fun ChatEntryCard(entry: ChatThreadEntry) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+    ) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Text(text = "질문", style = MaterialTheme.typography.labelLarge)
+            Text(text = entry.question, style = MaterialTheme.typography.bodyLarge)
+
+            Text(text = "답변", style = MaterialTheme.typography.labelLarge)
+            Text(text = entry.answer, style = MaterialTheme.typography.bodyMedium)
+
+            if (entry.context.isNotEmpty()) {
+                Text(text = "컨텍스트", style = MaterialTheme.typography.labelLarge)
+                entry.context.forEach { contextItem ->
+                    ContextChip(contextItem)
+                }
+            }
+
+            Text(
+                text = entry.filtersDescription,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ContextChip(item: ContextItemUi) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp)
+            .background(MaterialTheme.colorScheme.secondaryContainer, RoundedCornerShape(12.dp))
+            .padding(12.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Text(text = item.title, fontWeight = FontWeight.SemiBold)
+        Text(
+            text = item.preview,
+            maxLines = 3,
+            overflow = TextOverflow.Ellipsis,
+            style = MaterialTheme.typography.bodySmall,
+        )
+        Text(
+            text = item.meta,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSecondaryContainer,
+        )
+    }
+}
+
+@Composable
+private fun ChatInput(
+    value: String,
+    onValueChange: (String) -> Unit,
+    onSend: () -> Unit,
+    enabled: Boolean,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(16.dp)
+    ) {
+        OutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            modifier = Modifier.fillMaxWidth(),
+            placeholder = { Text("예: 이번 주 회의 일정 알려줘") },
+            enabled = enabled,
+            singleLine = false,
+            maxLines = 4,
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End,
+        ) {
+            Button(
+                onClick = onSend,
+                enabled = enabled && value.isNotBlank(),
+            ) {
+                if (enabled) {
+                    Text("질문 보내기")
+                } else {
+                    CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/agent_app/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/example/agent_app/ui/chat/ChatViewModel.kt
@@ -1,0 +1,88 @@
+package com.example.agent_app.ui.chat
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.agent_app.domain.chat.model.ChatResult
+import com.example.agent_app.domain.chat.model.QueryFilters
+import com.example.agent_app.domain.chat.usecase.ExecuteChatUseCase
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class ChatThreadEntry(
+    val question: String,
+    val answer: String,
+    val context: List<ContextItemUi>,
+    val filtersDescription: String,
+)
+
+data class ContextItemUi(
+    val id: String,
+    val title: String,
+    val preview: String,
+    val meta: String,
+)
+
+data class ChatUiState(
+    val entries: List<ChatThreadEntry> = emptyList(),
+    val isProcessing: Boolean = false,
+    val error: String? = null,
+)
+
+class ChatViewModel(
+    private val executeChatUseCase: ExecuteChatUseCase,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(ChatUiState())
+    val uiState: StateFlow<ChatUiState> = _uiState.asStateFlow()
+
+    fun submit(question: String) {
+        if (question.isBlank()) return
+        _uiState.update { it.copy(isProcessing = true, error = null) }
+        viewModelScope.launch {
+            runCatching { executeChatUseCase(question) }
+                .onSuccess { result ->
+                    _uiState.update { state ->
+                        state.copy(
+                            entries = state.entries + result.toThreadEntry(),
+                            isProcessing = false,
+                            error = null,
+                        )
+                    }
+                }
+                .onFailure { throwable ->
+                    _uiState.update { state ->
+                        state.copy(isProcessing = false, error = throwable.message ?: "알 수 없는 오류가 발생했습니다.")
+                    }
+                }
+        }
+    }
+
+    fun consumeError() {
+        _uiState.update { it.copy(error = null) }
+    }
+
+    private fun ChatResult.toThreadEntry(): ChatThreadEntry = ChatThreadEntry(
+        question = question.content,
+        answer = answer.content,
+        context = contextItems.map { item ->
+            ContextItemUi(
+                id = item.itemId,
+                title = item.title.ifBlank { "(제목 없음)" },
+                preview = item.body.take(400),
+                meta = "${item.source} • ${item.position}위 • score=${"%.2f".format(item.relevance)}",
+            )
+        },
+        filtersDescription = buildFiltersDescription(filters),
+    )
+
+    private fun buildFiltersDescription(filters: QueryFilters): String = buildString {
+        filters.startTimeMillis?.let { append("시작: $it ") }
+        filters.endTimeMillis?.let { append("끝: $it ") }
+        filters.source?.let { append("출처: $it ") }
+        if (filters.keywords.isNotEmpty()) {
+            append("키워드: ${filters.keywords.joinToString(", ")}")
+        }
+    }.ifBlank { "필터 없음" }
+}


### PR DESCRIPTION
## Summary
- add FTS and vector embedding support for ingest items plus a migration to version 2
- build a clean-architecture chat stack with query parsing, hybrid search, and OpenAI integration
- introduce a dedicated chatbot screen with bottom navigation and document the new workflow

## Testing
- ./gradlew test *(fails: Android SDK path not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ea09795538832090c16b24b92046fc